### PR TITLE
rework to support more sorts such as bitvector

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -105,14 +105,16 @@ pub fn build(b: *std.Build) !void {
     const run_example = b.step("example", "Runs the example");
     run_example.dependOn(&b.addRunArtifact(example).step);
 
-    const tests = b.addTest(.{ .root_module = b.createModule(.{
-        .root_source_file = b.path("src/tests.zig"),
-        .optimize = optimize,
-        .target = target,
-        .imports = &.{.{ .name = "z3", .module = z3_bindings }},
-    }) });
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tests.zig"),
+            .optimize = optimize,
+            .target = target,
+            .imports = &.{.{ .name = "z3", .module = z3_bindings }},
+        }),
+        .filters = b.option([]const []const u8, "test-filters", "test filters") orelse &.{},
+    });
     b.installArtifact(tests);
-    tests.filters = if (b.option([]const u8, "test-filter", "test filter")) |f| b.dupeStrings(&.{f}) else &.{};
     const run_tests = b.step("test", "Runs tests");
     run_tests.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/build.zig
+++ b/build.zig
@@ -101,8 +101,6 @@ pub fn build(b: *std.Build) !void {
         }),
     });
     example.root_module.addImport("z3", z3_bindings);
-    // enable running `valgrind --leak-check=full zig-out/bin/main`
-    example.root_module.valgrind = true;
     b.installArtifact(example);
     const run_example = b.step("example", "Runs the example");
     run_example.dependOn(&b.addRunArtifact(example).step);
@@ -114,7 +112,6 @@ pub fn build(b: *std.Build) !void {
         .imports = &.{.{ .name = "z3", .module = z3_bindings }},
     }) });
     b.installArtifact(tests);
-    tests.root_module.valgrind = true;
     tests.filters = if (b.option([]const u8, "test-filter", "test filter")) |f| b.dupeStrings(&.{f}) else &.{};
     const run_tests = b.step("test", "Runs tests");
     run_tests.dependOn(&b.addRunArtifact(tests).step);

--- a/build.zig
+++ b/build.zig
@@ -101,9 +101,22 @@ pub fn build(b: *std.Build) !void {
         }),
     });
     example.root_module.addImport("z3", z3_bindings);
-
+    // enable running `valgrind --leak-check=full zig-out/bin/main`
+    example.root_module.valgrind = true;
+    b.installArtifact(example);
     const run_example = b.step("example", "Runs the example");
     run_example.dependOn(&b.addRunArtifact(example).step);
+
+    const tests = b.addTest(.{ .root_module = b.createModule(.{
+        .root_source_file = b.path("src/tests.zig"),
+        .optimize = optimize,
+        .target = target,
+        .imports = &.{.{ .name = "z3", .module = z3_bindings }},
+    }) });
+    b.installArtifact(tests);
+    tests.root_module.valgrind = true;
+    const run_tests = b.step("test", "Runs tests");
+    run_tests.dependOn(&b.addRunArtifact(tests).step);
 }
 
 const z3_source_files: []const []const u8 = &.{

--- a/build.zig
+++ b/build.zig
@@ -115,6 +115,7 @@ pub fn build(b: *std.Build) !void {
     }) });
     b.installArtifact(tests);
     tests.root_module.valgrind = true;
+    tests.filters = if (b.option([]const u8, "test-filter", "test filter")) |f| b.dupeStrings(&.{f}) else &.{};
     const run_tests = b.step("test", "Runs tests");
     run_tests.dependOn(&b.addRunArtifact(tests).step);
 }

--- a/example.zig
+++ b/example.zig
@@ -2,25 +2,23 @@ const std = @import("std");
 const z3 = @import("z3");
 
 pub fn main() !void {
-    var gpa_state: std.heap.DebugAllocator(.{}) = .{};
-    const gpa = gpa_state.allocator();
-    try basic(gpa);
+    basic();
 }
 
-fn basic(gpa: std.mem.Allocator) !void {
-    var model = try z3.Model.init(.solver, gpa);
-    defer model.deinit(gpa);
+fn basic() void {
+    var model = z3.Model.initSolver();
+    defer model.deinit();
 
     const x = model.constant(.int, "x", .{});
     const y = model.constant(.int, "y", .{});
     const xaddy = x.add(&.{y});
-    const ten = model.int64(10);
+    const ten = model.fromInt64(10);
     model.assert(xaddy.eq(ten));
     std.debug.print("result: {}\n", .{model.check()});
 
     const pmodel = model.getLastModel();
     defer pmodel.deinit();
-    const xv = pmodel.eval(x, true).?.int64().?;
-    const yv = pmodel.eval(y, true).?.int64().?;
+    const xv = pmodel.eval(x, true).?.asInt64().?;
+    const yv = pmodel.eval(y, true).?.asInt64().?;
     std.debug.print("x: {} y: {}\n", .{ xv, yv });
 }

--- a/example.zig
+++ b/example.zig
@@ -8,19 +8,19 @@ pub fn main() !void {
 }
 
 fn basic(gpa: std.mem.Allocator) !void {
-    var solver = try z3.Solver.init(gpa);
-    defer solver.deinit(gpa);
+    var model = try z3.Model.init(.solver, gpa);
+    defer model.deinit(gpa);
 
-    const x = solver.constant(.int, "x", .{});
-    const y = solver.constant(.int, "y", .{});
+    const x = model.constant(.int, "x", .{});
+    const y = model.constant(.int, "y", .{});
     const xaddy = x.add(&.{y});
-    const ten = solver.int64(10);
-    solver.assert(xaddy.eq(ten));
-    std.debug.print("result: {}\n", .{solver.check()});
+    const ten = model.int64(10);
+    model.assert(xaddy.eq(ten));
+    std.debug.print("result: {}\n", .{model.check()});
 
-    const model = solver.getLastModel();
-    defer model.deinit();
-    const xv = model.eval(x, true).?.int64().?;
-    const yv = model.eval(y, true).?.int64().?;
+    const pmodel = model.getLastModel();
+    defer pmodel.deinit();
+    const xv = pmodel.eval(x, true).?.int64().?;
+    const yv = pmodel.eval(y, true).?.int64().?;
     std.debug.print("x: {} y: {}\n", .{ xv, yv });
 }

--- a/example.zig
+++ b/example.zig
@@ -1,25 +1,26 @@
 const std = @import("std");
 const z3 = @import("z3");
 
-const Model = z3.Model;
-
 pub fn main() !void {
-    basic();
+    var gpa_state: std.heap.DebugAllocator(.{}) = .{};
+    const gpa = gpa_state.allocator();
+    try basic(gpa);
 }
 
-fn basic() void {
-    var model = Model.init(.solver);
+fn basic(gpa: std.mem.Allocator) !void {
+    var solver = try z3.Solver.init(gpa);
+    defer solver.deinit(gpa);
+
+    const x = solver.constant(.int, "x", .{});
+    const y = solver.constant(.int, "y", .{});
+    const xaddy = x.add(&.{y});
+    const ten = solver.int64(10);
+    solver.assert(xaddy.eq(ten));
+    std.debug.print("result: {}\n", .{solver.check()});
+
+    const model = solver.getLastModel();
     defer model.deinit();
-
-    const x = model.constant(.int, "x");
-    const y = model.constant(.int, "y");
-
-    const constraint = model.eq(
-        model.add(&.{ x, y }),
-        model.int(10),
-    );
-
-    model.assert(constraint);
-
-    std.debug.print("result: {}\n", .{model.check()});
+    const xv = model.eval(x, true).?.int64().?;
+    const yv = model.eval(y, true).?.int64().?;
+    std.debug.print("x: {} y: {}\n", .{ xv, yv });
 }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -69,13 +69,13 @@ pub const Context = struct {
         c.Z3_del_context(ctx.inner);
     }
 
-    fn getSort(ctx: *Context, comptime tag: AstKind, args: anytype) Sort {
+    fn getSort(ctx: *Context, comptime tag: SortKind, args: anytype) Sort {
         return ctx.getSortByName(tag, "Z3_mk_" ++ @tagName(tag) ++ "_sort", args);
     }
 
     fn getSortByName(
         ctx: *Context,
-        comptime tag: AstKind,
+        comptime tag: SortKind,
         comptime mk_fn_name: []const u8,
         args: anytype,
     ) Sort {
@@ -95,80 +95,66 @@ pub const Context = struct {
     }
 };
 
-pub const AstKind = enum {
-    bool,
-    int,
-    real,
-    float,
-    float32,
-    float64,
-    string,
-    bv,
-    array,
-    set,
-    seq,
+pub const SortKind = enum(c_uint) {
+    /// `Z3_UNINTERPRETED_SORT`
+    uninterpreted = c.Z3_UNINTERPRETED_SORT,
+    /// `Z3_BOOL_SORT`
+    bool = c.Z3_BOOL_SORT,
+    /// `Z3_INT_SORT`
+    int = c.Z3_INT_SORT,
+    /// `Z3_REAL_SORT`
+    real = c.Z3_REAL_SORT,
+    /// `Z3_BV_SORT`
+    bv = c.Z3_BV_SORT,
+    /// `Z3_ARRAY_SORT`
+    array = c.Z3_ARRAY_SORT,
+    /// `Z3_DATATYPE_SORT`
+    datatype = c.Z3_DATATYPE_SORT,
+    /// `Z3_RELATION_SORT`
+    relation = c.Z3_RELATION_SORT,
+    /// `Z3_FINITE_DOMAIN_SORT`
+    finite_domain = c.Z3_FINITE_DOMAIN_SORT,
+    /// `Z3_FLOATING_POINT_SORT`
+    floating_point = c.Z3_FLOATING_POINT_SORT,
+    /// `Z3_ROUNDING_MODE_SORT`
+    rounding_mode = c.Z3_ROUNDING_MODE_SORT,
+    /// `Z3_SEQ_SORT`
+    seq = c.Z3_SEQ_SORT,
+    /// `Z3_RE_SORT`
+    re = c.Z3_RE_SORT,
+    /// `Z3_UNKNOWN_SORT`
+    unknown = c.Z3_UNKNOWN_SORT,
 
-    fn Data(tag: AstKind) type {
-        return switch (tag) {
+    inline fn Data(comptime tag: SortKind) type {
+        comptime return switch (tag) {
             .bool => Bool,
             .int => Int,
             .real => Real,
-            .float => Float,
-            .float32 => Float32,
-            .float64 => Float64,
-            .string => String,
+            .floating_point => Float,
             .bv => Bitvector,
             .array => Array,
-            .set => Set,
             .seq => Seq,
-        };
-    }
-
-    pub fn isNumeric(tag: AstKind) bool {
-        return switch (tag) {
-            .int,
-            .real,
-            .float,
-            .float32,
-            .float64,
-            => true,
-            else => false,
-        };
-    }
-
-    pub fn fromAst(lhs: anytype) AstKind {
-        return switch (c.Z3_get_sort_kind(lhs.ctx.inner, c.Z3_get_sort(lhs.ctx.inner, lhs.ast))) {
-            c.Z3_BOOL_SORT => .bool,
-            c.Z3_INT_SORT => .int,
-            c.Z3_REAL_SORT => .real,
-            c.Z3_BV_SORT => .bv,
-            c.Z3_ARRAY_SORT => .array,
-            c.Z3_FLOATING_POINT_SORT => .float,
-            c.Z3_SEQ_SORT => .seq,
-            c.Z3_RE_SORT,
-            c.Z3_CHAR_SORT,
-            c.Z3_TYPE_VAR,
-            c.Z3_UNKNOWN_SORT,
-            c.Z3_DATATYPE_SORT,
-            c.Z3_RELATION_SORT,
-            c.Z3_FINITE_DOMAIN_SORT,
-            c.Z3_ROUNDING_MODE_SORT,
-            => @panic("unimplemented"),
-            else => unreachable,
+            else => @compileError("TODO: Data() for " ++ @tagName(tag)),
         };
     }
 };
+
+const A = Ast;
 
 pub const Bool = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.bool);
+    pub const toString = A.toString;
+    pub const eq = A.eq;
+
     pub const @"and" = A.@"and";
     pub const @"or" = A.@"or";
+
     pub const xor = A.xor;
     pub const iff = A.iff;
     pub const implies = A.implies;
+
     pub const not = A.not;
     pub const ite = A.ite;
 };
@@ -177,8 +163,9 @@ pub const Int = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.int);
     pub const toString = A.toString;
+    pub const eq = A.eq;
+
     pub const add = A.add;
     pub const sub = A.sub;
     pub const mul = A.mul;
@@ -191,7 +178,6 @@ pub const Int = struct {
     pub const le = A.le;
     pub const gt = A.gt;
     pub const ge = A.ge;
-    pub const eq = A.eq;
 
     pub const asInt64 = A.asInt64;
 };
@@ -199,43 +185,22 @@ pub const Real = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.real);
     pub const toString = A.toString;
+    pub const eq = A.eq;
 };
 pub const Float = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.float);
     pub const toString = A.toString;
-};
-pub const Float32 = struct {
-    ctx: *Context,
-    ast: c.Z3_ast,
-
-    const A = Ast(.float32);
-    pub const toString = A.toString;
-};
-pub const Float64 = struct {
-    ctx: *Context,
-    ast: c.Z3_ast,
-
-    const A = Ast(.float64);
-    pub const toString = A.toString;
-};
-pub const String = struct {
-    ctx: *Context,
-    ast: c.Z3_ast,
-
-    const A = Ast(.string);
-    pub const toString = A.toString;
+    pub const eq = A.eq;
 };
 pub const Bitvector = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.bv);
     pub const toString = A.toString;
+    pub const eq = A.eq;
 
     pub const bvadd = A.bvadd;
     pub const bvsub = A.bvsub;
@@ -260,51 +225,62 @@ pub const Array = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.array);
     pub const toString = A.toString;
+    pub const eq = A.eq;
 
     pub const select = A.select;
+    pub const store = A.store;
     pub const asSet = A.asSet;
 };
 pub const Set = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.set);
     pub const toString = A.toString;
+    pub const eq = A.eq;
 };
 pub const Seq = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    const A = Ast(.seq);
     pub const toString = A.toString;
 };
-
 pub const Dynamic = struct {
     ctx: *Context,
     ast: c.Z3_ast,
-    ast_kind: AstKind,
+
+    pub const toString = A.toString;
+    pub const eq = A.eq;
+
+    pub fn sortKind(self: Dynamic) SortKind {
+        return @enumFromInt(c.Z3_get_sort_kind(
+            self.ctx.inner,
+            c.Z3_get_sort(self.ctx.inner, self.ast),
+        ));
+    }
 
     pub fn asSet(self: Dynamic) ?Set {
-        return switch (self.ast_kind) {
-            .array => switch (c.Z3_get_sort_kind(
-                self.ctx.inner,
-                c.Z3_get_array_sort_range(
+        switch (self.sortKind()) {
+            .array => {
+                const sort_kind: SortKind = @enumFromInt(c.Z3_get_sort_kind(
                     self.ctx.inner,
-                    c.Z3_get_sort(self.ctx.inner, self.ast),
-                ),
-            )) {
-                c.Z3_BOOL_SORT => return .{ .ctx = self.ctx, .ast = self.ast },
-                else => null,
+                    c.Z3_get_array_sort_range(
+                        self.ctx.inner,
+                        c.Z3_get_sort(self.ctx.inner, self.ast),
+                    ),
+                ));
+                switch (sort_kind) {
+                    .bool => return .{ .ctx = self.ctx, .ast = self.ast },
+                    else => return null,
+                }
             },
-            else => null,
-        };
+            else => return null,
+        }
     }
 };
 
-pub fn Ast(comptime ast_kind: AstKind) type {
-    return struct {
+// zig fmt: off
+const Ast = struct {
         pub fn deinit(self: anytype) void {
             c.Z3_dec_ref(self.ctx.inner, self.ast);
         }
@@ -312,9 +288,9 @@ pub fn Ast(comptime ast_kind: AstKind) type {
             return if (c.Z3_ast_to_string(self.ctx.inner, self.ast)) |s| std.mem.sliceTo(s, 0) else null;
         }
 
-        inline fn verify(comptime ok: bool, comptime message: []const u8) void {
+        inline fn verify(comptime ok: bool, T: type, comptime message: []const u8) void {
             comptime if (!ok)
-                @compileError(std.fmt.comptimePrint(message ++ ".  found '{t}'", .{ast_kind}));
+                @compileError(std.fmt.comptimePrint(message ++ ".  found '{s}'", .{@typeName(T)}));
         }
         inline fn Child(T: type) type {
             return switch (@typeInfo(T)) {
@@ -322,12 +298,15 @@ pub fn Ast(comptime ast_kind: AstKind) type {
                 else => T,
             };
         }
-        fn binop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
+        fn binopAny(R: type, lhs: anytype, rhs: anytype, func: @TypeOf(c.Z3_mk_div)) R {
             const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
             c.Z3_inc_ref(lhs.ctx.inner, ast);
             return .{ .ast = ast, .ctx = lhs.ctx };
         }
-        fn varop(lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) Child(@TypeOf(lhs)) {
+        fn binop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
+            return binopAny(R, lhs, rhs, func);
+        }
+        fn varop(R: type, lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) R {
             var buf: [16]c.Z3_ast = undefined;
             if (buf.len < rhss.len + 1) @panic("varop only supports up to 15 rhs args.");
             buf[0] = lhs.ast;
@@ -338,13 +317,16 @@ pub fn Ast(comptime ast_kind: AstKind) type {
         }
 
         // *** Numeric ops ***
+        inline fn verifyNumeric(T: type) void {
+            verify(T == Int or T == Float or T == Real, T, "expected numeric type");
+        }
         fn numericBinop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
-            verify(ast_kind.isNumeric(), "expected numeric ast kind");
+            verifyNumeric(Child(@TypeOf(lhs)));
             return binop(R, lhs, rhs, func);
         }
         fn numericVarop(lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) Child(@TypeOf(lhs)) {
-            verify(ast_kind.isNumeric(), "expected numeric ast kind");
-            return varop(lhs, rhss, func);
+            verifyNumeric(Child(@TypeOf(lhs)));
+            return varop(Child(@TypeOf(lhs)), lhs, rhss, func);
         }
 
         pub fn div(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
@@ -373,7 +355,7 @@ pub fn Ast(comptime ast_kind: AstKind) type {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_ge);
         }
         pub fn eq(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
-            return numericBinop(Bool, lhs, rhs, c.Z3_mk_eq);
+            return binop(Bool, lhs, rhs, c.Z3_mk_eq);
         }
 
         pub fn add(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
@@ -397,9 +379,7 @@ pub fn Ast(comptime ast_kind: AstKind) type {
         }
 
         // *** Bitvector ops ***
-
         fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
-            verify(ast_kind == .bv, "expected bitvector (bv) ast kind");
             return binop(R, lhs, rhs, func);
         }
 
@@ -471,11 +451,17 @@ pub fn Ast(comptime ast_kind: AstKind) type {
 
         // *** Array ops ***
         pub fn select(lhs: anytype, rhs: anytype) Dynamic {
-            return .{
-                .ctx = lhs.ctx,
-                .ast = c.Z3_mk_select(lhs.ctx.inner, lhs.ast, rhs.ast),
-                .ast_kind = .fromAst(lhs),
-            };
+            return binopAny(Dynamic, lhs, rhs, c.Z3_mk_select);
+        }
+        pub fn store(lhs: anytype, index: Int, value: anytype) Child(@TypeOf(lhs)) {
+            const ast = c.Z3_mk_store(
+                lhs.ctx.inner,
+                lhs.ast,
+                index.ast,
+                value.ast,
+            );
+            c.Z3_inc_ref(lhs.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = lhs.ctx };
         }
 
         // *** Bool ops ***
@@ -499,7 +485,7 @@ pub fn Ast(comptime ast_kind: AstKind) type {
         pub fn not(op: Bool) Bool {
             const ast = c.Z3_mk_not(op.ctx.inner, op.ast);
             c.Z3_inc_ref(op.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = &op.ctx };
+            return .{ .ast = ast, .ctx = op.ctx };
         }
 
         /// Create an AST node representing an if-then-else. If `predicate` is true,
@@ -511,8 +497,8 @@ pub fn Ast(comptime ast_kind: AstKind) type {
             c.Z3_inc_ref(predicate.ctx.inner, ast);
             return .{ .ast = ast, .ctx = predicate.ctx };
         }
-    };
-}
+};
+// zig fmt: on
 
 pub const Symbol = union(enum) {
     int: i32,
@@ -616,7 +602,7 @@ pub const Model = struct {
         return std.mem.sliceTo(str, 0);
     }
 
-    pub fn constant(m: *Model, comptime tag: AstKind, name: ?[:0]const u8, args: anytype) tag.Data() {
+    pub fn constant(m: *Model, comptime tag: SortKind, name: ?[:0]const u8, args: anytype) tag.Data() {
         const sort = m.ctx.getSort(tag, args);
         const sym = Symbol.asZ3(.{ .string = name }, &m.ctx);
         const ast = c.Z3_mk_const(m.ctx.inner, sym, sort.inner);
@@ -716,6 +702,13 @@ pub const Model = struct {
 
     pub fn getReasonUnknown(m: Model) ?[*:0]const u8 {
         return c.Z3_optimize_get_reason_unknown(m.ctx.inner, m.inner.optimize);
+    }
+
+    pub fn push(m: Model) void {
+        c.Z3_solver_push(m.ctx.inner, m.inner.solver);
+    }
+    pub fn pop(m: Model, n: c_uint) void {
+        c.Z3_solver_pop(m.ctx.inner, m.inner.solver, n);
     }
 };
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -141,6 +141,7 @@ pub const Bool = struct {
         return .{ .ast = ast, .ctx = predicate.ctx };
     }
 };
+
 pub const Int = struct {
     // storing ctx allows a builder pattern. i.e. `x.div(y)`
     ctx: *Context,
@@ -164,6 +165,7 @@ pub const Int = struct {
 
     pub const asInt64 = Ast.asInt64;
 };
+
 pub const Real = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -171,6 +173,7 @@ pub const Real = struct {
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
 };
+
 pub const Float = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -178,6 +181,7 @@ pub const Float = struct {
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
 };
+
 pub const String = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -185,6 +189,7 @@ pub const String = struct {
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
 };
+
 pub const Bitvector = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -264,6 +269,7 @@ pub const Bitvector = struct {
         return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsgt);
     }
 };
+
 pub const Array = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -274,6 +280,7 @@ pub const Array = struct {
     pub const select = Ast.select;
     pub const store = Ast.store;
 };
+
 pub const Set = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -281,12 +288,14 @@ pub const Set = struct {
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
 };
+
 pub const Seq = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
     pub const toString = Ast.toString;
 };
+
 pub const Dynamic = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -346,10 +355,12 @@ const Ast = struct {
             };
         }
     };
-    pub fn deinit(self: anytype) void {
+
+    fn deinit(self: anytype) void {
         c.Z3_dec_ref(self.ctx.inner, self.ast);
     }
-    pub fn toString(self: anytype) ?[]const u8 {
+
+    fn toString(self: anytype) ?[]const u8 {
         return if (c.Z3_ast_to_string(self.ctx.inner, self.ast)) |s| std.mem.sliceTo(s, 0) else null;
     }
 
@@ -357,20 +368,24 @@ const Ast = struct {
         comptime if (!ok)
             @compileError(std.fmt.comptimePrint(message ++ ".  found '{s}'", .{@typeName(T)}));
     }
+
     inline fn Child(T: type) type {
         return switch (@typeInfo(T)) {
             .pointer => |p| p.child,
             else => T,
         };
     }
+
     fn binopAny(R: type, lhs: anytype, rhs: anytype, func: @TypeOf(c.Z3_mk_div)) R {
         const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
         c.Z3_inc_ref(lhs.ctx.inner, ast);
         return .{ .ast = ast, .ctx = lhs.ctx };
     }
+
     fn binop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
         return binopAny(R, lhs, rhs, func);
     }
+
     fn varop(R: type, lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) R {
         var buf: [16]c.Z3_ast = undefined;
         if (buf.len < rhss.len + 1) @panic("varop only supports up to 15 rhs args.");
@@ -385,55 +400,66 @@ const Ast = struct {
     inline fn verifyNumeric(T: type) void {
         verify(T == Int or T == Float or T == Real, T, "expected numeric type");
     }
+
     fn numericBinop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
         verifyNumeric(Child(@TypeOf(lhs)));
         return binop(R, lhs, rhs, func);
     }
+
     fn numericVarop(lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) Child(@TypeOf(lhs)) {
         verifyNumeric(Child(@TypeOf(lhs)));
         return varop(Child(@TypeOf(lhs)), lhs, rhss, func);
     }
 
-    pub fn div(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+    fn div(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
         return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_div);
     }
-    pub fn rem(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+
+    fn rem(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
         return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_rem);
     }
-    pub fn mod(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+
+    fn mod(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
         return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_mod);
     }
-    pub fn power(lhs: anytype, rhs: Child(@TypeOf(lhs))) Real {
+
+    fn power(lhs: anytype, rhs: Child(@TypeOf(lhs))) Real {
         return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_power);
     }
 
-    pub fn lt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+    fn lt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
         return numericBinop(Bool, lhs, rhs, c.Z3_mk_lt);
     }
-    pub fn le(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+
+    fn le(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
         return numericBinop(Bool, lhs, rhs, c.Z3_mk_le);
     }
-    pub fn gt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+
+    fn gt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
         return numericBinop(Bool, lhs, rhs, c.Z3_mk_gt);
     }
-    pub fn ge(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+
+    fn ge(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
         return numericBinop(Bool, lhs, rhs, c.Z3_mk_ge);
     }
-    pub fn eq(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+
+    fn eq(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
         return binop(Bool, lhs, rhs, c.Z3_mk_eq);
     }
 
-    pub fn add(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+    fn add(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
         return numericVarop(lhs, rhss, c.Z3_mk_add);
     }
-    pub fn sub(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+
+    fn sub(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
         return numericVarop(lhs, rhss, c.Z3_mk_sub);
     }
-    pub fn mul(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+
+    fn mul(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
         return numericVarop(lhs, rhss, c.Z3_mk_mul);
     }
 
-    pub fn asInt64(lhs: anytype) ?i64 {
+    fn asInt64(lhs: anytype) ?i64 {
         var ret: i64 = undefined;
         return if (c.Z3_get_numeral_int64(lhs.ctx.inner, lhs.ast, &ret))
             ret
@@ -442,10 +468,10 @@ const Ast = struct {
     }
 
     // *** Array ops ***
-    pub fn select(lhs: anytype, rhs: anytype) Dynamic {
+    fn select(lhs: anytype, rhs: anytype) Dynamic {
         return binopAny(Dynamic, lhs, rhs, c.Z3_mk_select);
     }
-    pub fn store(lhs: anytype, index: Int, value: anytype) Child(@TypeOf(lhs)) {
+    fn store(lhs: anytype, index: Int, value: anytype) Child(@TypeOf(lhs)) {
         const ast = c.Z3_mk_store(
             lhs.ctx.inner,
             lhs.ast,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -164,6 +164,13 @@ pub const Bool = struct {
     ast: c.Z3_ast,
 
     const A = Ast(.bool);
+    pub const @"and" = A.@"and";
+    pub const @"or" = A.@"or";
+    pub const xor = A.xor;
+    pub const iff = A.iff;
+    pub const implies = A.implies;
+    pub const not = A.not;
+    pub const ite = A.ite;
 };
 pub const Int = struct {
     // storing ctx allows a builder pattern. i.e. `x.div(y)`
@@ -290,17 +297,33 @@ pub fn Ast(comptime ast_kind: AstKind) type {
             c.Z3_dec_ref(self.ctx.inner, self.ast);
         }
 
-        // *** Numeric ops ***
-        inline fn verifyNumeric() void {
-            comptime if (!ast_kind.isNumeric())
-                @compileError(std.fmt.comptimePrint("expected numeric ast kind.  found '{t}'", .{ast_kind}));
+        inline fn verify(comptime ok: bool, comptime message: []const u8) void {
+            comptime if (!ok)
+                @compileError(std.fmt.comptimePrint(message ++ ".  found '{t}'", .{ast_kind}));
         }
-
-        fn numericBinop(R: type, lhs: anytype, rhs: @TypeOf(lhs.*), func: @TypeOf(c.Z3_mk_div)) R {
-            verifyNumeric();
+        fn binop(R: type, lhs: anytype, rhs: @TypeOf(lhs.*), func: @TypeOf(c.Z3_mk_div)) R {
             const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
             c.Z3_inc_ref(lhs.ctx.inner, ast);
             return .{ .ast = ast, .ctx = lhs.ctx };
+        }
+        fn varop(lhs: anytype, rhss: []const @TypeOf(lhs.*), comptime func: @TypeOf(c.Z3_mk_add)) @TypeOf(lhs.*) {
+            var buf: [16]c.Z3_ast = undefined;
+            if (buf.len < rhss.len + 1) @panic("varop only supports up to 15 rhs args.");
+            buf[0] = lhs.ast;
+            for (0..rhss.len) |i| buf[i + 1] = rhss[i].ast;
+            const ast = func(lhs.ctx.inner, @intCast(rhss.len + 1), &buf);
+            c.Z3_inc_ref(lhs.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = lhs.ctx };
+        }
+
+        // *** Numeric ops ***
+        fn numericBinop(R: type, lhs: anytype, rhs: @TypeOf(lhs.*), func: @TypeOf(c.Z3_mk_div)) R {
+            verify(ast_kind.isNumeric(), "expected numeric ast kind");
+            return binop(R, lhs, rhs, func);
+        }
+        fn numericVarop(lhs: anytype, rhss: []const @TypeOf(lhs.*), comptime func: @TypeOf(c.Z3_mk_add)) @TypeOf(lhs.*) {
+            verify(ast_kind.isNumeric(), "expected numeric ast kind");
+            return varop(lhs, rhss, func);
         }
 
         pub fn div(lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
@@ -332,17 +355,6 @@ pub fn Ast(comptime ast_kind: AstKind) type {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_eq);
         }
 
-        fn numericVarop(lhs: anytype, rhss: []const @TypeOf(lhs.*), comptime func: @TypeOf(c.Z3_mk_add)) @TypeOf(lhs.*) {
-            verifyNumeric();
-            var buf: [16]c.Z3_ast = undefined;
-            if (buf.len < rhss.len + 1) @panic("numericVarop only supports up to 15 rhs args.");
-            buf[0] = lhs.ast;
-            for (0..rhss.len) |i| buf[i + 1] = rhss[i].ast;
-            const ast = func(lhs.ctx.inner, @intCast(rhss.len + 1), &buf);
-            c.Z3_inc_ref(lhs.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = lhs.ctx };
-        }
-
         pub fn add(lhs: anytype, rhss: []const @TypeOf(lhs.*)) @TypeOf(lhs.*) {
             return numericVarop(lhs, rhss, c.Z3_mk_add);
         }
@@ -364,16 +376,10 @@ pub fn Ast(comptime ast_kind: AstKind) type {
         }
 
         // *** Bitvector ops ***
-        inline fn verifyBitvector() void {
-            comptime if (ast_kind != .bv)
-                @compileError(std.fmt.comptimePrint("expected bitvector (bv) ast kind.  found '{t}'", .{ast_kind}));
-        }
 
         fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
-            verifyBitvector();
-            const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
-            c.Z3_inc_ref(lhs.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = lhs.ctx };
+            verify(ast_kind == .bv, "expected bitvector (bv) ast kind");
+            return binop(R, lhs, rhs, func);
         }
 
         /// Addition
@@ -449,6 +455,40 @@ pub fn Ast(comptime ast_kind: AstKind) type {
                 .ast = c.Z3_mk_select(lhs.ctx.inner, lhs.ast, rhs.ast),
                 .ast_kind = .fromAst(lhs),
             };
+        }
+
+        // *** Bool ops ***
+        pub fn @"and"(lhs: Bool, rhss: []const Bool) Bool {
+            return varop(Bool, lhs, rhss, c.Z3_mk_and);
+        }
+        pub fn @"or"(lhs: Bool, rhss: []const Bool) Bool {
+            return varop(Bool, lhs, rhss, c.Z3_mk_or);
+        }
+
+        pub fn xor(lhs: Bool, rhs: Bool) Bool {
+            return binop(Bool, lhs, rhs, c.Z3_mk_xor);
+        }
+        pub fn iff(lhs: Bool, rhs: Bool) Bool {
+            return binop(Bool, lhs, rhs, c.Z3_mk_iff);
+        }
+        pub fn implies(lhs: Bool, rhs: Bool) Bool {
+            return binop(Bool, lhs, rhs, c.Z3_mk_implies);
+        }
+
+        pub fn not(m: *Model, op: Bool) Bool {
+            const ast = c.Z3_mk_not(m.ctx, op.ast);
+            c.Z3_inc_ref(op.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = &m.ctx };
+        }
+
+        /// Create an AST node representing an if-then-else. If `predicate` is true,
+        /// the node results in `lhs`, otherwise it results in `rhs`.
+        ///
+        /// `rhs` and `lhs` must be the same sort, and the result type is that sort.
+        pub fn ite(m: *Model, predicate: Bool, lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
+            const ast = c.Z3_mk_ite(m.ctx.inner, predicate.ast, lhs.ast, rhs.ast);
+            c.Z3_inc_ref(m.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = &m.ctx };
         }
     };
 }
@@ -539,6 +579,22 @@ pub const Model = struct {
         });
     }
 
+    pub fn minimize(m: *const Model, objective: anytype) void {
+        _ = switch (m.prover) {
+            .solver => @panic("cannot minimze 'solver' prover"),
+            .optimize => |o| c.Z3_optimize_minimize(m.ctx.inner, o, objective.ast),
+        };
+    }
+
+    /// The string is still owned by the model, it's stored in a temporary buffer inside and dies on `deinit()`.
+    pub fn toString(m: *const Model) []const u8 {
+        const str = switch (m.prover) {
+            .solver => |s| c.Z3_solver_to_string(m.ctx.inner, s),
+            .optimize => |o| c.Z3_optimize_to_string(m.ctx.inner, o),
+        };
+        return std.mem.sliceTo(str, 0);
+    }
+
     pub fn constant(m: *Model, comptime tag: AstKind, name: ?[:0]const u8, args: anytype) tag.Data() {
         const sort = m.ctx.getSort(tag, args);
         const sym = Symbol.asZ3(.{ .string = name }, &m.ctx);
@@ -547,9 +603,22 @@ pub const Model = struct {
         return .{ .ctx = &m.ctx, .ast = ast };
     }
 
-    pub fn fromInt64(m: *Model, i: i64) Int {
+    pub fn fromInt(m: *Model, value: i32) Int {
         const sort = m.ctx.getSort(.int, .{});
-        const ast = c.Z3_mk_int64(m.ctx.inner, i, sort.inner);
+        const ast = c.Z3_mk_int(m.ctx.inner, value, sort.inner);
+        c.Z3_inc_ref(m.ctx.inner, ast);
+        return .{ .ctx = &m.ctx, .ast = ast };
+    }
+
+    pub fn fromInt64(m: *Model, value: i64) Int {
+        const sort = m.ctx.getSort(.int, .{});
+        const ast = c.Z3_mk_int64(m.ctx.inner, value, sort.inner);
+        c.Z3_inc_ref(m.ctx.inner, ast);
+        return .{ .ctx = &m.ctx, .ast = ast };
+    }
+
+    pub fn @"true"(m: *Model) Bool {
+        const ast = c.Z3_mk_true(m.ctx.inner);
         c.Z3_inc_ref(m.ctx.inner, ast);
         return .{ .ctx = &m.ctx, .ast = ast };
     }
@@ -646,6 +715,11 @@ pub const PartialModel = struct {
         }
 
         return null;
+    }
+
+    pub fn toString(p: *const PartialModel) []const u8 {
+        const str = c.Z3_model_to_string(p.ctx.inner, p.inner);
+        return std.mem.sliceTo(str, 0);
     }
 };
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -135,6 +135,28 @@ pub const AstKind = enum {
             else => false,
         };
     }
+
+    pub fn fromAst(lhs: anytype) AstKind {
+        return switch (c.Z3_get_sort_kind(lhs.ctx.inner, c.Z3_get_sort(lhs.ctx.inner, lhs.ast))) {
+            c.Z3_BOOL_SORT => .bool,
+            c.Z3_INT_SORT => .int,
+            c.Z3_REAL_SORT => .real,
+            c.Z3_BV_SORT => .bv,
+            c.Z3_ARRAY_SORT => .array,
+            c.Z3_FLOATING_POINT_SORT => .float,
+            c.Z3_SEQ_SORT => .seq,
+            c.Z3_RE_SORT,
+            c.Z3_CHAR_SORT,
+            c.Z3_TYPE_VAR,
+            c.Z3_UNKNOWN_SORT,
+            c.Z3_DATATYPE_SORT,
+            c.Z3_RELATION_SORT,
+            c.Z3_FINITE_DOMAIN_SORT,
+            c.Z3_ROUNDING_MODE_SORT,
+            => @panic("unimplemented"),
+            else => unreachable,
+        };
+    }
 };
 
 pub const Bool = struct {
@@ -224,6 +246,8 @@ pub const Array = struct {
     ast: c.Z3_ast,
 
     const A = Ast(.array);
+    pub const select = A.select;
+    pub const asSet = A.asSet;
 };
 pub const Set = struct {
     ctx: *Context,
@@ -238,7 +262,29 @@ pub const Seq = struct {
     const A = Ast(.seq);
 };
 
-pub fn Ast(comptime kind: AstKind) type {
+pub const Dynamic = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+    ast_kind: AstKind,
+
+    pub fn asSet(self: Dynamic) ?Set {
+        return switch (self.ast_kind) {
+            .array => switch (c.Z3_get_sort_kind(
+                self.ctx.inner,
+                c.Z3_get_array_sort_range(
+                    self.ctx.inner,
+                    c.Z3_get_sort(self.ctx.inner, self.ast),
+                ),
+            )) {
+                c.Z3_BOOL_SORT => return .{ .ctx = self.ctx, .ast = self.ast },
+                else => null,
+            },
+            else => null,
+        };
+    }
+};
+
+pub fn Ast(comptime ast_kind: AstKind) type {
     return struct {
         pub fn deinit(self: anytype) void {
             c.Z3_dec_ref(self.ctx.inner, self.ast);
@@ -246,8 +292,8 @@ pub fn Ast(comptime kind: AstKind) type {
 
         // *** Numeric ops ***
         inline fn verifyNumeric() void {
-            comptime if (!kind.isNumeric())
-                @compileError(std.fmt.comptimePrint("expected numeric ast kind.  found '{t}'", .{kind}));
+            comptime if (!ast_kind.isNumeric())
+                @compileError(std.fmt.comptimePrint("expected numeric ast kind.  found '{t}'", .{ast_kind}));
         }
 
         fn numericBinop(R: type, lhs: anytype, rhs: @TypeOf(lhs.*), func: @TypeOf(c.Z3_mk_div)) R {
@@ -319,8 +365,8 @@ pub fn Ast(comptime kind: AstKind) type {
 
         // *** Bitvector ops ***
         inline fn verifyBitvector() void {
-            comptime if (kind != .bv)
-                @compileError(std.fmt.comptimePrint("expected bitvector (bv) ast kind.  found '{t}'", .{kind}));
+            comptime if (ast_kind != .bv)
+                @compileError(std.fmt.comptimePrint("expected bitvector (bv) ast kind.  found '{t}'", .{ast_kind}));
         }
 
         fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
@@ -394,6 +440,15 @@ pub fn Ast(comptime kind: AstKind) type {
         /// Signed greater than
         pub fn bvsgt(lhs: Bitvector, rhs: Bitvector) Bool {
             return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsgt);
+        }
+
+        // *** Array ops ***
+        pub fn select(lhs: anytype, rhs: anytype) Dynamic {
+            return .{
+                .ctx = lhs.ctx,
+                .ast = c.Z3_mk_select(lhs.ctx.inner, lhs.ast, rhs.ast),
+                .ast_kind = .fromAst(lhs),
+            };
         }
     };
 }
@@ -547,20 +602,20 @@ pub const Model = struct {
     }
 
     pub fn array(m: *Model, domain: Sort, range: Sort) Sort {
-        const sort = c.Z3_mk_array_sort(m.ctx.inner, domain.z3_sort, range.z3_sort);
-        c.Z3_inc_ref(m.ctx.inner, sort);
+        const sort = c.Z3_mk_array_sort(m.ctx.inner, domain.inner, range.inner);
+        c.Z3_inc_ref(m.ctx.inner, c.Z3_sort_to_ast(m.ctx.inner, sort));
         return .{ .ctx = &m.ctx, .inner = sort };
     }
 
     pub fn set(m: *Model, elt: Sort) Sort {
-        const sort = c.Z3_mk_set_sort(m.ctx.inner, elt.z3_sort);
-        c.Z3_inc_ref(m.ctx.inner, sort);
+        const sort = c.Z3_mk_set_sort(m.ctx.inner, elt.inner);
+        c.Z3_inc_ref(m.ctx.inner, c.Z3_sort_to_ast(m.ctx.inner, sort));
         return .{ .ctx = &m.ctx, .inner = sort };
     }
 
     pub fn seq(m: *Model, elt: Sort) Sort {
-        const sort = c.Z3_mk_seq_sort(m.ctx.inner, elt.z3_sort);
-        c.Z3_inc_ref(m.ctx.inner, sort);
+        const sort = c.Z3_mk_seq_sort(m.ctx.inner, elt.inner);
+        c.Z3_inc_ref(m.ctx.inner, c.Z3_sort_to_ast(m.ctx.inner, sort));
         return .{ .ctx = &m.ctx, .inner = sort };
     }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -69,13 +69,13 @@ pub const Context = struct {
         c.Z3_del_context(ctx.inner);
     }
 
-    fn getSort(ctx: *Context, comptime tag: SortKind, args: anytype) Sort {
+    fn getSort(ctx: *Context, comptime tag: Ast.Tag, args: anytype) Sort {
         return ctx.getSortByName(tag, "Z3_mk_" ++ @tagName(tag) ++ "_sort", args);
     }
 
     fn getSortByName(
         ctx: *Context,
-        comptime tag: SortKind,
+        comptime tag: Ast.Tag,
         comptime mk_fn_name: []const u8,
         args: anytype,
     ) Sort {
@@ -92,50 +92,6 @@ pub const Context = struct {
         const sort = @call(.auto, @field(c, mk_fn_name), .{ctx.inner} ++ args);
         c.Z3_inc_ref(ctx.inner, c.Z3_sort_to_ast(ctx.inner, sort));
         return .{ .inner = sort, .ctx = ctx };
-    }
-};
-
-pub const SortKind = enum(c_uint) {
-    /// `Z3_UNINTERPRETED_SORT`
-    uninterpreted = c.Z3_UNINTERPRETED_SORT,
-    /// `Z3_BOOL_SORT`
-    bool = c.Z3_BOOL_SORT,
-    /// `Z3_INT_SORT`
-    int = c.Z3_INT_SORT,
-    /// `Z3_REAL_SORT`
-    real = c.Z3_REAL_SORT,
-    /// `Z3_BV_SORT`
-    bv = c.Z3_BV_SORT,
-    /// `Z3_ARRAY_SORT`
-    array = c.Z3_ARRAY_SORT,
-    /// `Z3_DATATYPE_SORT`
-    datatype = c.Z3_DATATYPE_SORT,
-    /// `Z3_RELATION_SORT`
-    relation = c.Z3_RELATION_SORT,
-    /// `Z3_FINITE_DOMAIN_SORT`
-    finite_domain = c.Z3_FINITE_DOMAIN_SORT,
-    /// `Z3_FLOATING_POINT_SORT`
-    floating_point = c.Z3_FLOATING_POINT_SORT,
-    /// `Z3_ROUNDING_MODE_SORT`
-    rounding_mode = c.Z3_ROUNDING_MODE_SORT,
-    /// `Z3_SEQ_SORT`
-    seq = c.Z3_SEQ_SORT,
-    /// `Z3_RE_SORT`
-    re = c.Z3_RE_SORT,
-    /// `Z3_UNKNOWN_SORT`
-    unknown = c.Z3_UNKNOWN_SORT,
-
-    inline fn Data(comptime tag: SortKind) type {
-        comptime return switch (tag) {
-            .bool => Bool,
-            .int => Int,
-            .real => Real,
-            .floating_point => Float,
-            .bv => Bitvector,
-            .array => Array,
-            .seq => Seq,
-            else => @compileError("TODO: Data() for " ++ @tagName(tag)),
-        };
     }
 };
 
@@ -211,6 +167,13 @@ pub const Real = struct {
     pub const eq = Ast.eq;
 };
 pub const Float = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
+};
+pub const String = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
@@ -327,7 +290,7 @@ pub const Dynamic = struct {
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
 
-    pub fn sortKind(self: Dynamic) SortKind {
+    pub fn sortKind(self: Dynamic) Sort.Tag {
         return @enumFromInt(c.Z3_get_sort_kind(
             self.ctx.inner,
             c.Z3_get_sort(self.ctx.inner, self.ast),
@@ -337,7 +300,7 @@ pub const Dynamic = struct {
     pub fn asSet(self: Dynamic) ?Set {
         switch (self.sortKind()) {
             .array => {
-                const sort_kind: SortKind = @enumFromInt(c.Z3_get_sort_kind(
+                const sort_kind: Sort.Tag = @enumFromInt(c.Z3_get_sort_kind(
                     self.ctx.inner,
                     c.Z3_get_array_sort_range(
                         self.ctx.inner,
@@ -356,6 +319,29 @@ pub const Dynamic = struct {
 
 /// common operations used by multiple Ast impls
 const Ast = struct {
+    pub const Tag = enum {
+        bool,
+        int,
+        real,
+        float32,
+        float64,
+        bv,
+        array,
+        seq,
+
+        inline fn Data(comptime tag: Tag) type {
+            comptime return switch (tag) {
+                .bool => Bool,
+                .int => Int,
+                .real => Real,
+                .float32 => Float,
+                .float64 => Float,
+                .bv => Bitvector,
+                .array => Array,
+                .seq => Seq,
+            };
+        }
+    };
     pub fn deinit(self: anytype) void {
         c.Z3_dec_ref(self.ctx.inner, self.ast);
     }
@@ -484,6 +470,37 @@ pub const Symbol = union(enum) {
 pub const Sort = struct {
     ctx: *Context,
     inner: c.Z3_sort,
+
+    pub const Tag = enum(c_uint) {
+        /// `Z3_UNINTERPRETED_SORT`
+        uninterpreted = c.Z3_UNINTERPRETED_SORT,
+        /// `Z3_BOOL_SORT`
+        bool = c.Z3_BOOL_SORT,
+        /// `Z3_INT_SORT`
+        int = c.Z3_INT_SORT,
+        /// `Z3_REAL_SORT`
+        real = c.Z3_REAL_SORT,
+        /// `Z3_BV_SORT`
+        bv = c.Z3_BV_SORT,
+        /// `Z3_ARRAY_SORT`
+        array = c.Z3_ARRAY_SORT,
+        /// `Z3_DATATYPE_SORT`
+        datatype = c.Z3_DATATYPE_SORT,
+        /// `Z3_RELATION_SORT`
+        relation = c.Z3_RELATION_SORT,
+        /// `Z3_FINITE_DOMAIN_SORT`
+        finite_domain = c.Z3_FINITE_DOMAIN_SORT,
+        /// `Z3_FLOATING_POINT_SORT`
+        floating_point = c.Z3_FLOATING_POINT_SORT,
+        /// `Z3_ROUNDING_MODE_SORT`
+        rounding_mode = c.Z3_ROUNDING_MODE_SORT,
+        /// `Z3_SEQ_SORT`
+        seq = c.Z3_SEQ_SORT,
+        /// `Z3_RE_SORT`
+        re = c.Z3_RE_SORT,
+        /// `Z3_UNKNOWN_SORT`
+        unknown = c.Z3_UNKNOWN_SORT,
+    };
 };
 
 const Prover = enum { solver, optimize };
@@ -569,7 +586,7 @@ pub const Model = struct {
         return std.mem.sliceTo(str, 0);
     }
 
-    pub fn constant(m: *Model, comptime tag: SortKind, name: ?[:0]const u8, args: anytype) tag.Data() {
+    pub fn constant(m: *Model, comptime tag: Ast.Tag, name: ?[:0]const u8, args: anytype) tag.Data() {
         const sort = m.ctx.getSort(tag, args);
         const sym = Symbol.asZ3(.{ .string = name }, &m.ctx);
         const ast = c.Z3_mk_const(m.ctx.inner, sym, sort.inner);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -139,6 +139,7 @@ pub const SortKind = enum(c_uint) {
     }
 };
 
+// *** Ast implementations ***
 pub const Bool = struct {
     ctx: *Context,
     ast: c.Z3_ast,
@@ -146,15 +147,38 @@ pub const Bool = struct {
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
 
-    pub const @"and" = Ast.@"and";
-    pub const @"or" = Ast.@"or";
+    pub fn @"and"(lhs: Bool, rhss: []const Bool) Bool {
+        return Ast.varop(Bool, lhs, rhss, c.Z3_mk_and);
+    }
+    pub fn @"or"(lhs: Bool, rhss: []const Bool) Bool {
+        return Ast.varop(Bool, lhs, rhss, c.Z3_mk_or);
+    }
 
-    pub const xor = Ast.xor;
-    pub const iff = Ast.iff;
-    pub const implies = Ast.implies;
+    pub fn xor(lhs: Bool, rhs: Bool) Bool {
+        return Ast.binop(Bool, lhs, rhs, c.Z3_mk_xor);
+    }
+    pub fn iff(lhs: Bool, rhs: Bool) Bool {
+        return Ast.binop(Bool, lhs, rhs, c.Z3_mk_iff);
+    }
+    pub fn implies(lhs: Bool, rhs: Bool) Bool {
+        return Ast.binop(Bool, lhs, rhs, c.Z3_mk_implies);
+    }
 
-    pub const not = Ast.not;
-    pub const ite = Ast.ite;
+    pub fn not(op: Bool) Bool {
+        const ast = c.Z3_mk_not(op.ctx.inner, op.ast);
+        c.Z3_inc_ref(op.ctx.inner, ast);
+        return .{ .ast = ast, .ctx = op.ctx };
+    }
+
+    /// Create an AST node representing an if-then-else. If `predicate` is true,
+    /// the node results in `lhs`, otherwise it results in `rhs`.
+    ///
+    /// `rhs` and `lhs` must be the same sort, and the result type is that sort.
+    pub fn ite(predicate: Bool, lhs: anytype, rhs: Ast.Child(@TypeOf(lhs))) Ast.Child(@TypeOf(lhs)) {
+        const ast = c.Z3_mk_ite(predicate.ctx.inner, predicate.ast, lhs.ast, rhs.ast);
+        c.Z3_inc_ref(predicate.ctx.inner, ast);
+        return .{ .ast = ast, .ctx = predicate.ctx };
+    }
 };
 pub const Int = struct {
     // storing ctx allows a builder pattern. i.e. `x.div(y)`
@@ -200,24 +224,77 @@ pub const Bitvector = struct {
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
 
-    pub const bvadd = Ast.bvadd;
-    pub const bvsub = Ast.bvsub;
-    pub const bvmul = Ast.bvmul;
-    pub const bvudiv = Ast.bvudiv;
-    pub const bvsdiv = Ast.bvsdiv;
-    pub const bvurem = Ast.bvurem;
-    pub const bvsrem = Ast.bvsrem;
-    pub const bvsmod = Ast.bvsmod;
-    pub const bvult = Ast.bvult;
-    pub const bvslt = Ast.bvslt;
-    pub const bvule = Ast.bvule;
-    pub const bvsle = Ast.bvsle;
-    pub const bvuge = Ast.bvuge;
-    pub const bvsge = Ast.bvsge;
-    pub const bvugt = Ast.bvugt;
-    pub const bvsgt = Ast.bvsgt;
-
     pub const asInt64 = Ast.asInt64;
+
+    fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
+        return Ast.binop(R, lhs, rhs, func);
+    }
+
+    /// Addition
+    pub fn bvadd(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvadd);
+    }
+    /// Subtraction
+    pub fn bvsub(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsub);
+    }
+    /// Multiplication
+    pub fn bvmul(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvmul);
+    }
+    /// Unsigned division
+    pub fn bvudiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvudiv);
+    }
+    /// Signed division
+    pub fn bvsdiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsdiv);
+    }
+    /// Unsigned remainder
+    pub fn bvurem(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvurem);
+    }
+    /// Signed remainder (sign follows dividend)
+    pub fn bvsrem(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsrem);
+    }
+    /// Signed remainder (sign follows divisor)
+    pub fn bvsmod(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsmod);
+    }
+
+    /// Unsigned less than
+    pub fn bvult(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvult);
+    }
+    /// Signed less than
+    pub fn bvslt(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvslt);
+    }
+    /// Unsigned less than or equal
+    pub fn bvule(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvule);
+    }
+    /// Signed less than or equal
+    pub fn bvsle(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsle);
+    }
+    /// Unsigned greater or equal
+    pub fn bvuge(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvuge);
+    }
+    /// Signed greater or equal
+    pub fn bvsge(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsge);
+    }
+    /// Unsigned greater than
+    pub fn bvugt(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvugt);
+    }
+    /// Signed greater than
+    pub fn bvsgt(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsgt);
+    }
 };
 pub const Array = struct {
     ctx: *Context,
@@ -277,6 +354,7 @@ pub const Dynamic = struct {
     }
 };
 
+/// common operations used by multiple Ast impls
 const Ast = struct {
     pub fn deinit(self: anytype) void {
         c.Z3_dec_ref(self.ctx.inner, self.ast);
@@ -373,77 +451,6 @@ const Ast = struct {
             null;
     }
 
-    // *** Bitvector ops ***
-    fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
-        return binop(R, lhs, rhs, func);
-    }
-
-    /// Addition
-    pub fn bvadd(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvadd);
-    }
-    /// Subtraction
-    pub fn bvsub(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsub);
-    }
-    /// Multiplication
-    pub fn bvmul(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvmul);
-    }
-    /// Unsigned division
-    pub fn bvudiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvudiv);
-    }
-    /// Signed division
-    pub fn bvsdiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsdiv);
-    }
-    /// Unsigned remainder
-    pub fn bvurem(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvurem);
-    }
-    /// Signed remainder (sign follows dividend)
-    pub fn bvsrem(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsrem);
-    }
-    /// Signed remainder (sign follows divisor)
-    pub fn bvsmod(lhs: Bitvector, rhs: Bitvector) Bitvector {
-        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsmod);
-    }
-
-    /// Unsigned less than
-    pub fn bvult(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvult);
-    }
-    /// Signed less than
-    pub fn bvslt(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvslt);
-    }
-    /// Unsigned less than or equal
-    pub fn bvule(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvule);
-    }
-    /// Signed less than or equal
-    pub fn bvsle(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsle);
-    }
-    /// Unsigned greater or equal
-    pub fn bvuge(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvuge);
-    }
-    /// Signed greater or equal
-    pub fn bvsge(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsge);
-    }
-    /// Unsigned greater than
-    pub fn bvugt(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvugt);
-    }
-    /// Signed greater than
-    pub fn bvsgt(lhs: Bitvector, rhs: Bitvector) Bool {
-        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsgt);
-    }
-
     // *** Array ops ***
     pub fn select(lhs: anytype, rhs: anytype) Dynamic {
         return binopAny(Dynamic, lhs, rhs, c.Z3_mk_select);
@@ -457,40 +464,6 @@ const Ast = struct {
         );
         c.Z3_inc_ref(lhs.ctx.inner, ast);
         return .{ .ast = ast, .ctx = lhs.ctx };
-    }
-
-    // *** Bool ops ***
-    pub fn @"and"(lhs: Bool, rhss: []const Bool) Bool {
-        return varop(Bool, lhs, rhss, c.Z3_mk_and);
-    }
-    pub fn @"or"(lhs: Bool, rhss: []const Bool) Bool {
-        return varop(Bool, lhs, rhss, c.Z3_mk_or);
-    }
-
-    pub fn xor(lhs: Bool, rhs: Bool) Bool {
-        return binop(Bool, lhs, rhs, c.Z3_mk_xor);
-    }
-    pub fn iff(lhs: Bool, rhs: Bool) Bool {
-        return binop(Bool, lhs, rhs, c.Z3_mk_iff);
-    }
-    pub fn implies(lhs: Bool, rhs: Bool) Bool {
-        return binop(Bool, lhs, rhs, c.Z3_mk_implies);
-    }
-
-    pub fn not(op: Bool) Bool {
-        const ast = c.Z3_mk_not(op.ctx.inner, op.ast);
-        c.Z3_inc_ref(op.ctx.inner, ast);
-        return .{ .ast = ast, .ctx = op.ctx };
-    }
-
-    /// Create an AST node representing an if-then-else. If `predicate` is true,
-    /// the node results in `lhs`, otherwise it results in `rhs`.
-    ///
-    /// `rhs` and `lhs` must be the same sort, and the result type is that sort.
-    pub fn ite(predicate: Bool, lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-        const ast = c.Z3_mk_ite(predicate.ctx.inner, predicate.ast, lhs.ast, rhs.ast);
-        c.Z3_inc_ref(predicate.ctx.inner, ast);
-        return .{ .ast = ast, .ctx = predicate.ctx };
     }
 };
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -16,8 +16,10 @@ pub const Context = struct {
         bool: ?c.Z3_sort = null,
         int: ?c.Z3_sort = null,
         real: ?c.Z3_sort = null,
+        float16: ?c.Z3_sort = null,
         float32: ?c.Z3_sort = null,
         float64: ?c.Z3_sort = null,
+        float128: ?c.Z3_sort = null,
         string: ?c.Z3_sort = null,
     };
 
@@ -85,9 +87,8 @@ pub const Context = struct {
     ) Sort {
         const name = @tagName(tag);
         if (@hasField(CachedSorts, name)) {
-            comptime assert(args.len == 0);
             if (@field(ctx.cached_sorts, name)) |sort| return .{ .inner = sort, .ctx = ctx };
-            const sort = @field(c, mk_fn_name)(ctx.inner);
+            const sort = @call(.auto, @field(c, mk_fn_name), .{ctx.inner} ++ args);
             @field(ctx.cached_sorts, name) = sort;
             c.Z3_inc_ref(ctx.inner, c.Z3_sort_to_ast(ctx.inner, sort));
             return .{ .inner = sort, .ctx = ctx };
@@ -106,6 +107,7 @@ pub const Bool = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 
     pub fn @"and"(lhs: Bool, rhss: []const Bool) Bool {
         return Ast.varop(Bool, lhs, rhss, c.Z3_mk_and);
@@ -148,6 +150,7 @@ pub const Int = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 
     pub const add = Ast.add;
     pub const sub = Ast.sub;
@@ -171,6 +174,7 @@ pub const Real = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 };
 
 pub const Float = struct {
@@ -179,6 +183,7 @@ pub const Float = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 };
 
 pub const String = struct {
@@ -187,6 +192,7 @@ pub const String = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 };
 
 pub const Bitvector = struct {
@@ -195,6 +201,7 @@ pub const Bitvector = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 
     pub const asInt64 = Ast.asInt64;
 
@@ -275,6 +282,7 @@ pub const Array = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 
     pub const select = Ast.select;
     pub const store = Ast.store;
@@ -286,6 +294,7 @@ pub const Set = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 };
 
 pub const Seq = struct {
@@ -301,6 +310,7 @@ pub const Dynamic = struct {
 
     pub const toString = Ast.toString;
     pub const eq = Ast.eq;
+    pub const getSort = Ast.getSort;
 
     pub fn sortKind(self: Dynamic) Sort.Tag {
         return @enumFromInt(c.Z3_get_sort_kind(
@@ -330,13 +340,16 @@ pub const Dynamic = struct {
 };
 
 /// common operations used by multiple Ast impls
-const Ast = struct {
+pub const Ast = struct {
     pub const Tag = enum {
         bool,
         int,
         real,
+        float16,
         float32,
         float64,
+        float128,
+        float,
         bv,
         array,
         seq,
@@ -346,8 +359,7 @@ const Ast = struct {
                 .bool => Bool,
                 .int => Int,
                 .real => Real,
-                .float32 => Float,
-                .float64 => Float,
+                .float16, .float32, .float64, .float128, .float => Float,
                 .bv => Bitvector,
                 .array => Array,
                 .seq => Seq,
@@ -361,6 +373,12 @@ const Ast = struct {
 
     fn toString(self: anytype) ?[]const u8 {
         return if (c.Z3_ast_to_string(self.ctx.inner, self.ast)) |s| std.mem.sliceTo(s, 0) else null;
+    }
+
+    fn getSort(self: anytype) Sort {
+        const sort = c.Z3_get_sort(self.ctx.inner, self.ast);
+        c.Z3_inc_ref(self.ctx.inner, c.Z3_sort_to_ast(self.ctx.inner, sort));
+        return .{ .ctx = self.ctx, .inner = sort };
     }
 
     inline fn verify(comptime ok: bool, T: type, comptime message: []const u8) void {
@@ -530,6 +548,23 @@ pub const Sort = struct {
         /// `Z3_UNKNOWN_SORT`
         unknown = c.Z3_UNKNOWN_SORT,
     };
+
+    pub fn kind(self: Sort) Tag {
+        return @enumFromInt(c.Z3_get_sort_kind(self.ctx.inner, self.inner));
+    }
+
+    pub fn exponentSize(self: Sort) ?u32 {
+        return if (self.kind() == .floating_point)
+            c.Z3_fpa_get_ebits(self.ctx.inner, self.inner)
+        else
+            null;
+    }
+    pub fn significandSize(self: Sort) ?u32 {
+        return if (self.kind() == .floating_point)
+            c.Z3_fpa_get_sbits(self.ctx.inner, self.inner)
+        else
+            null;
+    }
 };
 
 const Prover = enum { solver, optimize };
@@ -623,6 +658,14 @@ pub const Model = struct {
         return .{ .ctx = &m.ctx, .ast = ast };
     }
 
+    pub fn constantFloat(m: *Model, T: type, name: ?[:0]const u8) Float {
+        const sort = m.float(T);
+        const sym = Symbol.asZ3(.{ .string = name }, &m.ctx);
+        const ast = c.Z3_mk_const(m.ctx.inner, sym, sort.inner);
+        c.Z3_inc_ref(m.ctx.inner, ast);
+        return .{ .ctx = &m.ctx, .ast = ast };
+    }
+
     pub fn fromInt(m: *Model, value: i32) Int {
         const sort = m.ctx.getSort(.int, .{});
         const ast = c.Z3_mk_int(m.ctx.inner, value, sort.inner);
@@ -672,8 +715,10 @@ pub const Model = struct {
         const ebits: u32 = std.math.floatExponentBits(T);
         const sbits: u32 = std.math.floatMantissaBits(T) + 1;
         const tag: Ast.Tag = switch (T) {
+            f16 => .float16,
             f32 => .float32,
             f64 => .float64,
+            f128 => .float128,
             else => .float,
         };
         return m.ctx.getSortByName(tag, "Z3_mk_fpa_sort", .{ ebits, sbits });

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -12,7 +12,7 @@ pub const Context = struct {
     cached_sorts: CachedSorts,
 
     /// sorts that can be cached which only require a single *Model argument
-    const CachedSorts = struct {
+    pub const CachedSorts = struct {
         bool: ?c.Z3_sort = null,
         int: ?c.Z3_sort = null,
         real: ?c.Z3_sort = null,
@@ -21,49 +21,48 @@ pub const Context = struct {
         string: ?c.Z3_sort = null,
     };
 
-    pub const ConfigParam = union(enum) {
-        timeout: c_uint,
-        rlimit: c_uint,
-        type_check: bool,
-        well_sorted_check: bool,
-        auto_config: bool,
-        proof: bool,
-        model: bool,
-        model_validate: bool,
-        dump_models: bool,
-        stats: bool,
-        trace: bool,
-        trace_file_name: [*:0]const u8,
-        dot_proof_file: [*:0]const u8,
-        unsat_core: bool,
-        debug_ref_count: bool,
-        smtlib2_compliant: bool,
-        encoding: enum { unicode, bmp, ascii },
+    pub const Config = struct {
+        timeout: ?u32 = null,
+        rlimit: ?u32 = null,
+        type_check: ?bool = null,
+        well_sorted_check: ?bool = null,
+        auto_config: ?bool = null,
+        proof: ?bool = null,
+        model: ?bool = null,
+        model_validate: ?bool = null,
+        dump_models: ?bool = null,
+        stats: ?bool = null,
+        trace: ?bool = null,
+        trace_file_name: ?[*:0]const u8 = null,
+        dot_proof_file: ?[*:0]const u8 = null,
+        unsat_core: ?bool = null,
+        debug_ref_count: ?bool = null,
+        smtlib2_compliant: ?bool = null,
+        encoding: ?enum { unicode, bmp, ascii } = null,
 
         // TODO support additional params and renames: https://github.com/Z3Prover/z3/blob/49703f8bba0e73fbd2aa6b180f8afdaeadd4d7a4/src/util/gparams.cpp#L44-L73
     };
 
-    pub const Config = []const ConfigParam;
-
     pub fn init(config: Config) Context {
         const cfg = c.Z3_mk_config();
         defer c.Z3_del_config(cfg);
-        for (config) |param| {
-            var buf: [64]u8 = @splat(0);
-            const value_str: [:0]const u8 = switch (param) {
-                inline else => |payload| switch (@TypeOf(payload)) {
-                    c_uint => std.fmt.bufPrintZ(&buf, "{}", .{payload}) catch unreachable,
+
+        inline for (@typeInfo(Config).@"struct".fields) |f| {
+            var buf: [64]u8 = undefined;
+            if (@field(config, f.name)) |payload| {
+                const value_str: [:0]const u8 = switch (@TypeOf(payload)) {
+                    u32 => std.fmt.bufPrintZ(&buf, "{}", .{payload}) catch unreachable,
                     bool => if (payload) "true" else "false",
                     [*:0]const u8 => std.mem.sliceTo(payload, 0),
                     else => switch (@typeInfo(@TypeOf(payload))) {
                         .@"enum" => @tagName(payload),
                         else => {
-                            @compileError("TODO: support ConfigParam payload type '" ++ @typeName(@TypeOf(payload)) ++ "'");
+                            @compileError("TODO: support Config payload type '" ++ @typeName(@TypeOf(payload)) ++ "'");
                         },
                     },
-                },
-            };
-            c.Z3_set_param_value(cfg, @tagName(param).ptr, value_str.ptr);
+                };
+                c.Z3_set_param_value(cfg, f.name.ptr, value_str.ptr);
+            }
         }
         const inner = c.Z3_mk_context_rc(cfg);
         c.Z3_set_error_handler(inner, errorHandler);
@@ -501,7 +500,7 @@ pub const Sort = struct {
     ctx: *Context,
     inner: c.Z3_sort,
 
-    pub const Tag = enum(c_uint) {
+    pub const Tag = enum(u32) {
         /// `Z3_UNINTERPRETED_SORT`
         uninterpreted = c.Z3_UNINTERPRETED_SORT,
         /// `Z3_BOOL_SORT`
@@ -559,7 +558,7 @@ pub const Model = struct {
     }
 
     pub fn initSolver() Model {
-        return initConfig(.solver, &.{.{ .proof = true }});
+        return initConfig(.solver, .{ .proof = true });
     }
 
     pub fn initConfig(comptime p: Prover, config: Context.Config) Model {
@@ -670,20 +669,14 @@ pub const Model = struct {
 
     /// T must be a floating point type
     pub fn float(m: *Model, comptime T: type) Sort {
-        const ebits: c_uint = std.math.floatExponentBits(T);
-        const sbits: c_uint = std.math.floatMantissaBits(T) + 1;
-        if (@typeInfo(T) != .float) @compileError("expected floating point type. found '" ++ @typeName(T) ++ "'");
-        switch (T) {
-            f32 => {
-                comptime std.debug.assert(ebits == 8 and sbits == 24);
-                return m.ctx.getSortByName(.float32, "Z3_mk_fpa_sort", .{ ebits, sbits });
-            },
-            f64 => {
-                comptime std.debug.assert(ebits == 11 and sbits == 53);
-                return m.ctx.getSortByName(.float64, "Z3_mk_fpa_sort", .{ ebits, sbits });
-            },
-            else => return m.ctx.getSortByName(.float, "Z3_mk_fpa_sort", .{ ebits, sbits }),
-        }
+        const ebits: u32 = std.math.floatExponentBits(T);
+        const sbits: u32 = std.math.floatMantissaBits(T) + 1;
+        const tag: Ast.Tag = switch (T) {
+            f32 => .float32,
+            f64 => .float64,
+            else => .float,
+        };
+        return m.ctx.getSortByName(tag, "Z3_mk_fpa_sort", .{ ebits, sbits });
     }
 
     pub fn string(m: *Model) Sort {
@@ -721,7 +714,7 @@ pub const Model = struct {
     pub fn push(m: Model) void {
         c.Z3_solver_push(m.ctx.inner, m.inner.solver);
     }
-    pub fn pop(m: Model, n: c_uint) void {
+    pub fn pop(m: Model, n: u32) void {
         c.Z3_solver_pop(m.ctx.inner, m.inner.solver, n);
     }
 };

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -313,142 +313,173 @@ pub const Sort = struct {
     inner: c.Z3_sort,
 };
 
-pub const Solver = struct {
-    ctx: Context,
-    inner: c.Z3_solver,
+const Prover = enum { solver, optimize };
 
-    pub fn initCtx(ctx: Context) Solver {
-        const inner = c.Z3_mk_solver(ctx.inner);
-        c.Z3_solver_inc_ref(ctx.inner, inner);
+pub const Model = struct {
+    ctx: Context,
+    inner: union(Prover) {
+        solver: c.Z3_solver,
+        optimize: c.Z3_optimize,
+    },
+
+    pub fn initCtx(comptime p: Prover, ctx: Context) Model {
+        const inner = @unionInit(@FieldType(Model, "inner"), @tagName(p), switch (p) {
+            .solver => s: {
+                const solver = c.Z3_mk_solver(ctx.inner);
+                c.Z3_solver_inc_ref(ctx.inner, solver);
+                break :s solver;
+            },
+            .optimize => o: {
+                const optimize = c.Z3_mk_optimize(ctx.inner);
+                c.Z3_optimize_inc_ref(ctx.inner, optimize);
+                break :o optimize;
+            },
+        });
         return .{ .ctx = ctx, .inner = inner };
     }
 
-    pub fn initConfig(allocator: std.mem.Allocator, config_kvs: Context.ConfigKvs) !Solver {
-        return .initCtx(try .init(allocator, config_kvs));
+    pub fn initConfig(comptime p: Prover, allocator: std.mem.Allocator, config_kvs: Context.ConfigKvs) !Model {
+        return .initCtx(p, try .init(allocator, config_kvs));
     }
 
-    pub fn init(gpa: std.mem.Allocator) !Solver {
-        return initConfig(gpa, &.{.{ "proof", "true" }});
+    pub fn init(comptime p: Prover, gpa: std.mem.Allocator) !Model {
+        return initConfig(p, gpa, if (p == .solver) &.{.{ "proof", "true" }} else &.{});
     }
 
-    pub fn deinit(s: Solver, allocator: std.mem.Allocator) void {
-        c.Z3_solver_dec_ref(s.ctx.inner, s.inner);
-        s.ctx.deinit(allocator);
+    pub fn deinit(m: Model, allocator: std.mem.Allocator) void {
+        switch (m.inner) {
+            .solver => |s| c.Z3_solver_dec_ref(m.ctx.inner, s),
+            .optimize => |o| c.Z3_optimize_dec_ref(m.ctx.inner, o),
+        }
+        m.ctx.deinit(allocator);
     }
 
     /// Panics if
     /// 1. `check()` wasn't ran before calling `getLastModel()`.
     /// 2. The last `check()` call didn't return `true`.
-    pub fn getLastModel(s: Solver) Model {
-        const m = c.Z3_solver_get_model(s.ctx.inner, s.inner);
-        c.Z3_model_inc_ref(s.ctx.inner, m);
-        return .{ .ctx = s.ctx, .inner = m };
+    pub fn getLastModel(m: Model) PartialModel {
+        const model = switch (m.inner) {
+            .solver => |x| c.Z3_solver_get_model(m.ctx.inner, x),
+            .optimize => |x| c.Z3_optimize_get_model(m.ctx.inner, x),
+        };
+        c.Z3_model_inc_ref(m.ctx.inner, model);
+        return .{ .ctx = m.ctx, .inner = model };
     }
 
-    pub fn assert(s: Solver, ast: anytype) void {
-        c.Z3_solver_assert(s.ctx.inner, s.inner, ast.ast);
+    pub fn assert(m: Model, ast: anytype) void {
+        switch (m.inner) {
+            .solver => |x| c.Z3_solver_assert(m.ctx.inner, x, ast.ast),
+            .optimize => |x| c.Z3_optimize_assert(m.ctx.inner, x, ast.ast),
+        }
     }
 
-    pub fn check(s: Solver) SatResult {
-        return @enumFromInt(c.Z3_solver_check(s.ctx.inner, s.inner));
+    pub fn check(m: Model) SatResult {
+        return @enumFromInt(switch (m.inner) {
+            .solver => |x| c.Z3_solver_check(m.ctx.inner, x),
+            .optimize => |x| c.Z3_optimize_check(m.ctx.inner, x, 0, null),
+        });
     }
 
-    pub fn constant(s: Solver, comptime tag: AstKind, name: ?[:0]const u8, args: anytype) tag.Type() {
-        const sort = s.ctx.getSort(tag, args);
-        const sym = Symbol.asZ3(.{ .string = name }, s.ctx);
-        const ast = c.Z3_mk_const(s.ctx.inner, sym, sort);
-        c.Z3_inc_ref(s.ctx.inner, ast);
-        return .{ .ctx = s.ctx, .ast = ast };
+    pub fn constant(m: Model, comptime tag: AstKind, name: ?[:0]const u8, args: anytype) tag.Type() {
+        const sort = m.ctx.getSort(tag, args);
+        const sym = Symbol.asZ3(.{ .string = name }, m.ctx);
+        const ast = c.Z3_mk_const(m.ctx.inner, sym, sort);
+        c.Z3_inc_ref(m.ctx.inner, ast);
+        return .{ .ctx = m.ctx, .ast = ast };
     }
 
-    pub fn int64(s: Solver, i: i64) Int {
-        const sort = s.ctx.getSort(.int, .{});
-        const ast = c.Z3_mk_int64(s.ctx.inner, i, sort);
-        c.Z3_inc_ref(s.ctx.inner, ast);
-        return .{ .ctx = s.ctx, .ast = ast };
+    pub fn int64(m: Model, i: i64) Int {
+        const sort = m.ctx.getSort(.int, .{});
+        const ast = c.Z3_mk_int64(m.ctx.inner, i, sort);
+        c.Z3_inc_ref(m.ctx.inner, ast);
+        return .{ .ctx = m.ctx, .ast = ast };
     }
 
-    pub fn bvFromInt64(s: Solver, i: i64, sz: u32) Bitvector {
-        const sort = s.ctx.getSort(.bv, .{sz});
-        const ast = c.Z3_mk_int64(s.ctx.inner, i, sort);
-        c.Z3_inc_ref(s.ctx.inner, ast);
-        return .{ .ctx = s.ctx, .ast = ast };
+    pub fn bvFromInt64(m: Model, i: i64, sz: u32) Bitvector {
+        const sort = m.ctx.getSort(.bv, .{sz});
+        const ast = c.Z3_mk_int64(m.ctx.inner, i, sort);
+        c.Z3_inc_ref(m.ctx.inner, ast);
+        return .{ .ctx = m.ctx, .ast = ast };
     }
 
-    fn makeSort(s: Solver, comptime func: @TypeOf(c.Z3_mk_bool_sort)) Sort {
-        const sort = func(s.ctx.inner);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    fn makeSort(m: Model, comptime func: @TypeOf(c.Z3_mk_bool_sort)) Sort {
+        const sort = func(m.ctx.inner);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
     }
 
-    pub fn boolean(s: Solver) Sort {
-        return s.makeSort(c.Z3_mk_bool_sort);
+    pub fn boolean(m: Model) Sort {
+        return m.makeSort(c.Z3_mk_bool_sort);
     }
 
-    pub fn int(s: Solver) Sort {
-        return s.makeSort(c.Z3_mk_int_sort);
+    pub fn int(m: Model) Sort {
+        return m.makeSort(c.Z3_mk_int_sort);
     }
 
-    pub fn real(s: Solver) Sort {
-        return s.makeSort(c.Z3_mk_real_sort);
+    pub fn real(m: Model) Sort {
+        return m.makeSort(c.Z3_mk_real_sort);
     }
 
-    pub fn float(s: Solver, ebits: u32, sbits: u32) Sort {
-        const sort = c.Z3_mk_fpa_sort(s.ctx.inner, ebits, sbits);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    pub fn float(m: Model, ebits: u32, sbits: u32) Sort {
+        const sort = c.Z3_mk_fpa_sort(m.ctx.inner, ebits, sbits);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
     }
 
-    pub fn float32(s: Solver) Sort {
-        const sort = c.Z3_mk_fpa_sort(s.ctx.inner, 8, 24);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    pub fn float32(m: Model) Sort {
+        const sort = c.Z3_mk_fpa_sort(m.ctx.inner, 8, 24);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
     }
 
-    pub fn double(s: Solver) Sort {
-        const sort = c.Z3_mk_fpa_sort(s.ctx.inner, 11, 53);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    pub fn double(m: Model) Sort {
+        const sort = c.Z3_mk_fpa_sort(m.ctx.inner, 11, 53);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
     }
 
-    pub fn string(s: Solver) Sort {
-        return s.makeSort(c.Z3_mk_string_sort);
+    pub fn string(m: Model) Sort {
+        return m.makeSort(c.Z3_mk_string_sort);
     }
 
-    pub fn bv(s: Solver, sz: u32) Sort {
-        const sort = c.Z3_mk_bv_sort(s.ctx.inner, sz);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    pub fn bv(m: Model, sz: u32) Sort {
+        const sort = c.Z3_mk_bv_sort(m.ctx.inner, sz);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
     }
 
-    pub fn array(s: Solver, domain: Sort, range: Sort) Sort {
-        const sort = c.Z3_mk_array_sort(s.ctx.inner, domain.z3_sort, range.z3_sort);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    pub fn array(m: Model, domain: Sort, range: Sort) Sort {
+        const sort = c.Z3_mk_array_sort(m.ctx.inner, domain.z3_sort, range.z3_sort);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
     }
 
-    pub fn set(s: Solver, elt: *const Sort) Sort {
-        const sort = c.Z3_mk_set_sort(s.ctx.inner, elt.z3_sort);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    pub fn set(m: Model, elt: *const Sort) Sort {
+        const sort = c.Z3_mk_set_sort(m.ctx.inner, elt.z3_sort);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
     }
 
-    pub fn seq(s: Solver, elt: *const Sort) Sort {
-        const sort = c.Z3_mk_seq_sort(s.ctx.inner, elt.z3_sort);
-        c.Z3_inc_ref(s.ctx.inner, sort);
-        return .{ .ctx = s.ctx, .inner = sort };
+    pub fn seq(m: Model, elt: *const Sort) Sort {
+        const sort = c.Z3_mk_seq_sort(m.ctx.inner, elt.z3_sort);
+        c.Z3_inc_ref(m.ctx.inner, sort);
+        return .{ .ctx = m.ctx, .inner = sort };
+    }
+
+    pub fn getReasonUnknown(m: Model) ?[*:0]const u8 {
+        return c.Z3_optimize_get_reason_unknown(m.ctx.inner, m.inner.optimize);
     }
 };
 
-pub const Model = struct {
+pub const PartialModel = struct {
     ctx: Context,
     inner: c.Z3_model,
 
-    pub fn deinit(m: Model) void {
+    pub fn deinit(m: PartialModel) void {
         c.Z3_model_dec_ref(m.ctx.inner, m.inner);
     }
 
-    pub fn eval(m: Model, ast: anytype, model_completion: bool) ?@TypeOf(ast) {
+    pub fn eval(m: PartialModel, ast: anytype, model_completion: bool) ?@TypeOf(ast) {
         var ret = ast;
         if (c.Z3_model_eval(
             m.ctx.inner,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -21,7 +21,7 @@ pub const Context = struct {
         string: ?c.Z3_sort = null,
     };
 
-    const ConfigParam = union(enum) {
+    pub const ConfigParam = union(enum) {
         timeout: c_uint,
         rlimit: c_uint,
         type_check: bool,
@@ -49,13 +49,18 @@ pub const Context = struct {
         const cfg = c.Z3_mk_config();
         defer c.Z3_del_config(cfg);
         for (config) |param| {
-            var buf: [64]u8 = undefined;
+            var buf: [64]u8 = @splat(0);
             const value_str: [:0]const u8 = switch (param) {
                 inline else => |payload| switch (@TypeOf(payload)) {
-                    c_uint => std.fmt.bufPrintZ(&buf, "{}", .{payload}) catch @panic("unreachable"),
+                    c_uint => std.fmt.bufPrintZ(&buf, "{}", .{payload}) catch unreachable,
                     bool => if (payload) "true" else "false",
                     [*:0]const u8 => std.mem.sliceTo(payload, 0),
-                    else => unreachable,
+                    else => switch (@typeInfo(@TypeOf(payload))) {
+                        .@"enum" => @tagName(payload),
+                        else => {
+                            @compileError("TODO: support ConfigParam payload type '" ++ @typeName(@TypeOf(payload)) ++ "'");
+                        },
+                    },
                 },
             };
             c.Z3_set_param_value(cfg, @tagName(param).ptr, value_str.ptr);
@@ -268,7 +273,6 @@ pub const Array = struct {
 
     pub const select = Ast.select;
     pub const store = Ast.store;
-    pub const asSet = Ast.asSet;
 };
 pub const Set = struct {
     ctx: *Context,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -9,52 +9,89 @@ fn errorHandler(ctx: c.Z3_context, e: c.Z3_error_code) callconv(.c) void {
 
 pub const Context = struct {
     inner: c.Z3_context,
-    /// stored on the heap to keep Context small and copyable
-    cached_sorts: *CachedSorts,
+    cached_sorts: CachedSorts,
 
-    /// sorts that can be cached whose mk_*_sort method has one argument
+    /// sorts that can be cached which only require a single *Model argument
     const CachedSorts = struct {
         bool: ?c.Z3_sort = null,
         int: ?c.Z3_sort = null,
         real: ?c.Z3_sort = null,
         float32: ?c.Z3_sort = null,
-        double: ?c.Z3_sort = null,
+        float64: ?c.Z3_sort = null,
         string: ?c.Z3_sort = null,
     };
 
-    pub const ConfigKvs = []const [2][:0]const u8;
+    const ConfigParam = union(enum) {
+        timeout: c_uint,
+        rlimit: c_uint,
+        type_check: bool,
+        well_sorted_check: bool,
+        auto_config: bool,
+        proof: bool,
+        model: bool,
+        model_validate: bool,
+        dump_models: bool,
+        stats: bool,
+        trace: bool,
+        trace_file_name: [*:0]const u8,
+        dot_proof_file: [*:0]const u8,
+        unsat_core: bool,
+        debug_ref_count: bool,
+        smtlib2_compliant: bool,
+        encoding: enum { unicode, bmp, ascii },
 
-    pub fn init(allocator: std.mem.Allocator, kvs: ConfigKvs) !Context {
+        // TODO support additional params and renames: https://github.com/Z3Prover/z3/blob/49703f8bba0e73fbd2aa6b180f8afdaeadd4d7a4/src/util/gparams.cpp#L44-L73
+    };
+
+    pub const Config = []const ConfigParam;
+
+    pub fn init(config: Config) Context {
         const cfg = c.Z3_mk_config();
         defer c.Z3_del_config(cfg);
-        for (kvs) |kv| {
-            c.Z3_set_param_value(cfg, kv[0].ptr, kv[1].ptr);
+        for (config) |param| {
+            var buf: [64]u8 = undefined;
+            const value_str: [:0]const u8 = switch (param) {
+                inline else => |payload| switch (@TypeOf(payload)) {
+                    c_uint => std.fmt.bufPrintZ(&buf, "{}", .{payload}) catch @panic("unreachable"),
+                    bool => if (payload) "true" else "false",
+                    [*:0]const u8 => std.mem.sliceTo(payload, 0),
+                    else => unreachable,
+                },
+            };
+            c.Z3_set_param_value(cfg, @tagName(param).ptr, value_str.ptr);
         }
         const inner = c.Z3_mk_context_rc(cfg);
         c.Z3_set_error_handler(inner, errorHandler);
-        const cached_sorts = try allocator.create(CachedSorts);
-        cached_sorts.* = .{};
-        return .{ .inner = inner, .cached_sorts = cached_sorts };
+        return .{ .inner = inner, .cached_sorts = .{} };
     }
 
-    pub fn deinit(ctx: Context, allocator: std.mem.Allocator) void {
-        allocator.destroy(ctx.cached_sorts);
+    pub fn deinit(ctx: *const Context) void {
         c.Z3_del_context(ctx.inner);
     }
 
-    fn getSort(ctx: Context, comptime tag: AstKind, args: anytype) c.Z3_sort {
-        if (@hasField(CachedSorts, @tagName(tag))) {
+    fn getSort(ctx: *Context, comptime tag: AstKind, args: anytype) Sort {
+        return ctx.getSortByName(tag, "Z3_mk_" ++ @tagName(tag) ++ "_sort", args);
+    }
+
+    fn getSortByName(
+        ctx: *Context,
+        comptime tag: AstKind,
+        comptime mk_fn_name: []const u8,
+        args: anytype,
+    ) Sort {
+        const name = @tagName(tag);
+        if (@hasField(CachedSorts, name)) {
             comptime assert(args.len == 0);
-            if (@field(ctx.cached_sorts, @tagName(tag))) |sort| return sort;
-            const sort = @field(c, "Z3_mk_" ++ @tagName(tag) ++ "_sort")(ctx.inner);
+            if (@field(ctx.cached_sorts, name)) |sort| return .{ .inner = sort, .ctx = ctx };
+            const sort = @field(c, mk_fn_name)(ctx.inner);
+            @field(ctx.cached_sorts, name) = sort;
             c.Z3_inc_ref(ctx.inner, c.Z3_sort_to_ast(ctx.inner, sort));
-            @field(ctx.cached_sorts, @tagName(tag)) = sort;
-            return sort;
+            return .{ .inner = sort, .ctx = ctx };
         }
 
-        const sort = @call(.auto, @field(c, "Z3_mk_" ++ @tagName(tag) ++ "_sort"), .{ctx.inner} ++ args);
+        const sort = @call(.auto, @field(c, mk_fn_name), .{ctx.inner} ++ args);
         c.Z3_inc_ref(ctx.inner, c.Z3_sort_to_ast(ctx.inner, sort));
-        return sort;
+        return .{ .inner = sort, .ctx = ctx };
     }
 };
 
@@ -64,21 +101,21 @@ pub const AstKind = enum {
     real,
     float,
     float32,
-    double,
+    float64,
     string,
     bv,
     array,
     set,
     seq,
 
-    fn Type(tag: AstKind) type {
+    fn Data(tag: AstKind) type {
         return switch (tag) {
             .bool => Bool,
             .int => Int,
             .real => Real,
             .float => Float,
             .float32 => Float32,
-            .double => Double,
+            .float64 => Float64,
             .string => String,
             .bv => Bitvector,
             .array => Array,
@@ -93,102 +130,164 @@ pub const AstKind = enum {
             .real,
             .float,
             .float32,
-            .double,
+            .float64,
             => true,
             else => false,
         };
     }
 };
 
-pub const Bool = Ast(struct {
-    pub const ast_kind: AstKind = .bool;
-});
-pub const Int = Ast(struct {
-    pub const ast_kind: AstKind = .int;
-});
-pub const Real = Ast(struct {
-    pub const ast_kind: AstKind = .real;
-});
-pub const Float = Ast(struct {
-    pub const ast_kind: AstKind = .float;
-});
-pub const Float32 = Ast(struct {
-    pub const ast_kind: AstKind = .float32;
-});
-pub const Double = Ast(struct {
-    pub const ast_kind: AstKind = .double;
-});
-pub const String = Ast(struct {
-    pub const ast_kind: AstKind = .string;
-});
-pub const Bitvector = Ast(struct {
-    pub const ast_kind: AstKind = .bv;
-});
-pub const Array = Ast(struct {
-    pub const ast_kind: AstKind = .array;
-});
-pub const Set = Ast(struct {
-    pub const ast_kind: AstKind = .set;
-});
-pub const Seq = Ast(struct {
-    pub const ast_kind: AstKind = .seq;
-});
+pub const Bool = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
 
-comptime {
-    assert(Bool != Int);
-}
+    const A = Ast(.bool);
+};
+pub const Int = struct {
+    // storing ctx allows a builder pattern. i.e. `x.div(y)`
+    ctx: *Context,
+    ast: c.Z3_ast,
 
-pub fn Ast(T: type) type {
+    const A = Ast(.int);
+    pub const add = A.add;
+    pub const sub = A.sub;
+    pub const mul = A.mul;
+
+    pub const div = A.div;
+    pub const rem = A.rem;
+    pub const modulo = A.modulo;
+    pub const power = A.power;
+    pub const lt = A.lt;
+    pub const le = A.le;
+    pub const gt = A.gt;
+    pub const ge = A.ge;
+    pub const eq = A.eq;
+
+    pub const asInt64 = A.asInt64;
+};
+pub const Real = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.real);
+};
+pub const Float = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.float);
+};
+pub const Float32 = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.float32);
+};
+pub const Float64 = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.float64);
+};
+pub const String = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.string);
+};
+pub const Bitvector = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.bv);
+    pub const bvadd = A.bvadd;
+    pub const bvsub = A.bvsub;
+    pub const bvmul = A.bvmul;
+    pub const bvudiv = A.bvudiv;
+    pub const bvsdiv = A.bvsdiv;
+    pub const bvurem = A.bvurem;
+    pub const bvsrem = A.bvsrem;
+    pub const bvsmod = A.bvsmod;
+    pub const bvult = A.bvult;
+    pub const bvslt = A.bvslt;
+    pub const bvule = A.bvule;
+    pub const bvsle = A.bvsle;
+    pub const bvuge = A.bvuge;
+    pub const bvsge = A.bvsge;
+    pub const bvugt = A.bvugt;
+    pub const bvsgt = A.bvsgt;
+
+    pub const asInt64 = A.asInt64;
+};
+pub const Array = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.array);
+};
+pub const Set = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.set);
+};
+pub const Seq = struct {
+    ctx: *Context,
+    ast: c.Z3_ast,
+
+    const A = Ast(.seq);
+};
+
+pub fn Ast(comptime kind: AstKind) type {
     return struct {
-        // store ctx to allow a builder pattern. i.e. `x.div(y)`
-        ctx: Context,
-        ast: c.Z3_ast,
-
-        const Self = @This();
-
-        pub fn deinit(self: Self) void {
+        pub fn deinit(self: anytype) void {
             c.Z3_dec_ref(self.ctx.inner, self.ast);
         }
 
         // *** Numeric ops ***
-        fn numericBinop(R: type, lhs: Self, rhs: Self, func: @TypeOf(c.Z3_mk_div)) R {
-            comptime if (!T.ast_kind.isNumeric()) unreachable;
+        inline fn verifyNumeric() void {
+            comptime if (!kind.isNumeric())
+                @compileError(std.fmt.comptimePrint("expected numeric ast kind.  found '{t}'", .{kind}));
+        }
+
+        fn numericBinop(R: type, lhs: anytype, rhs: @TypeOf(lhs.*), func: @TypeOf(c.Z3_mk_div)) R {
+            verifyNumeric();
             const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
             c.Z3_inc_ref(lhs.ctx.inner, ast);
             return .{ .ast = ast, .ctx = lhs.ctx };
         }
 
-        pub fn div(lhs: Self, rhs: Self) Self {
-            return numericBinop(Self, lhs, rhs, c.Z3_mk_div);
+        pub fn div(lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
+            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_div);
         }
-        pub fn rem(lhs: Self, rhs: Self) Self {
-            return numericBinop(Self, lhs, rhs, c.Z3_mk_rem);
+        pub fn rem(lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
+            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_rem);
         }
-        pub fn mod(lhs: Self, rhs: Self) Self {
-            return numericBinop(Self, lhs, rhs, c.Z3_mk_mod);
+        pub fn mod(lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
+            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_mod);
         }
-        pub fn power(lhs: Self, rhs: Self) Real {
-            return numericBinop(Self, lhs, rhs, c.Z3_mk_power);
+        pub fn power(lhs: anytype, rhs: @TypeOf(lhs.*)) Real {
+            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_power);
         }
 
-        pub fn lt(lhs: Self, rhs: Self) Bool {
+        pub fn lt(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_lt);
         }
-        pub fn le(lhs: Self, rhs: Self) Bool {
+        pub fn le(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_le);
         }
-        pub fn gt(lhs: Self, rhs: Self) Bool {
+        pub fn gt(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_gt);
         }
-        pub fn ge(lhs: Self, rhs: Self) Bool {
+        pub fn ge(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_ge);
         }
-        pub fn eq(lhs: Self, rhs: Self) Bool {
+        pub fn eq(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_eq);
         }
 
-        fn numericVarop(lhs: Self, rhss: []const Self, comptime func: @TypeOf(c.Z3_mk_add)) Self {
-            comptime if (!T.ast_kind.isNumeric()) unreachable;
+        fn numericVarop(lhs: anytype, rhss: []const @TypeOf(lhs.*), comptime func: @TypeOf(c.Z3_mk_add)) @TypeOf(lhs.*) {
+            verifyNumeric();
             var buf: [16]c.Z3_ast = undefined;
             if (buf.len < rhss.len + 1) @panic("numericVarop only supports up to 15 rhs args.");
             buf[0] = lhs.ast;
@@ -198,29 +297,34 @@ pub fn Ast(T: type) type {
             return .{ .ast = ast, .ctx = lhs.ctx };
         }
 
-        pub fn add(lhs: Self, rhss: []const Self) Self {
+        pub fn add(lhs: anytype, rhss: []const @TypeOf(lhs.*)) @TypeOf(lhs.*) {
             return numericVarop(lhs, rhss, c.Z3_mk_add);
         }
 
-        pub fn sub(lhs: Self, rhss: []const Self) Self {
+        pub fn sub(lhs: anytype, rhss: []const @TypeOf(lhs.*)) @TypeOf(lhs.*) {
             return numericVarop(lhs, rhss, c.Z3_mk_sub);
         }
 
-        pub fn mul(lhs: Self, rhss: []const Self) Self {
+        pub fn mul(lhs: anytype, rhss: []const @TypeOf(lhs.*)) @TypeOf(lhs.*) {
             return numericVarop(lhs, rhss, c.Z3_mk_mul);
         }
 
-        pub fn int64(ast: Self) ?i64 {
+        pub fn asInt64(lhs: anytype) ?i64 {
             var ret: i64 = undefined;
-            return if (c.Z3_get_numeral_int64(ast.ctx.inner, ast.ast, &ret))
+            return if (c.Z3_get_numeral_int64(lhs.ctx.inner, lhs.ast, &ret))
                 ret
             else
                 null;
         }
 
         // *** Bitvector ops ***
+        inline fn verifyBitvector() void {
+            comptime if (kind != .bv)
+                @compileError(std.fmt.comptimePrint("expected bitvector (bv) ast kind.  found '{t}'", .{kind}));
+        }
+
         fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
-            comptime if (T.ast_kind != .bv) unreachable;
+            verifyBitvector();
             const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
             c.Z3_inc_ref(lhs.ctx.inner, ast);
             return .{ .ast = ast, .ctx = lhs.ctx };
@@ -300,7 +404,7 @@ pub const Symbol = union(enum) {
 
     pub const Tag = std.meta.Tag(Symbol);
 
-    fn asZ3(sym: Symbol, ctx: Context) c.Z3_symbol {
+    fn asZ3(sym: Symbol, ctx: *const Context) c.Z3_symbol {
         return switch (sym) {
             .int => |i| c.Z3_mk_int_symbol(ctx.inner, i),
             .string => |s| c.Z3_mk_string_symbol(ctx.inner, @ptrCast(s)),
@@ -309,7 +413,7 @@ pub const Symbol = union(enum) {
 };
 
 pub const Sort = struct {
-    ctx: Context,
+    ctx: *Context,
     inner: c.Z3_sort,
 };
 
@@ -322,7 +426,7 @@ pub const Model = struct {
         optimize: c.Z3_optimize,
     },
 
-    pub fn initCtx(comptime p: Prover, ctx: Context) Model {
+    pub fn init(comptime p: Prover, ctx: Context) Model {
         const inner = @unionInit(@FieldType(Model, "inner"), @tagName(p), switch (p) {
             .solver => s: {
                 const solver = c.Z3_mk_solver(ctx.inner);
@@ -338,132 +442,126 @@ pub const Model = struct {
         return .{ .ctx = ctx, .inner = inner };
     }
 
-    pub fn initConfig(comptime p: Prover, allocator: std.mem.Allocator, config_kvs: Context.ConfigKvs) !Model {
-        return .initCtx(p, try .init(allocator, config_kvs));
+    pub fn initSolver() Model {
+        return initConfig(.solver, &.{.{ .proof = true }});
     }
 
-    pub fn init(comptime p: Prover, gpa: std.mem.Allocator) !Model {
-        return initConfig(p, gpa, if (p == .solver) &.{.{ "proof", "true" }} else &.{});
+    pub fn initConfig(comptime p: Prover, config: Context.Config) Model {
+        return init(p, Context.init(config));
     }
 
-    pub fn deinit(m: Model, allocator: std.mem.Allocator) void {
+    pub fn deinit(m: *const Model) void {
         switch (m.inner) {
             .solver => |s| c.Z3_solver_dec_ref(m.ctx.inner, s),
             .optimize => |o| c.Z3_optimize_dec_ref(m.ctx.inner, o),
         }
-        m.ctx.deinit(allocator);
+        m.ctx.deinit();
     }
 
     /// Panics if
     /// 1. `check()` wasn't ran before calling `getLastModel()`.
     /// 2. The last `check()` call didn't return `true`.
-    pub fn getLastModel(m: Model) PartialModel {
+    pub fn getLastModel(m: *const Model) PartialModel {
         const model = switch (m.inner) {
             .solver => |x| c.Z3_solver_get_model(m.ctx.inner, x),
             .optimize => |x| c.Z3_optimize_get_model(m.ctx.inner, x),
         };
         c.Z3_model_inc_ref(m.ctx.inner, model);
-        return .{ .ctx = m.ctx, .inner = model };
+        return .{ .ctx = &m.ctx, .inner = model };
     }
 
-    pub fn assert(m: Model, ast: anytype) void {
+    pub fn assert(m: *const Model, ast: anytype) void {
         switch (m.inner) {
             .solver => |x| c.Z3_solver_assert(m.ctx.inner, x, ast.ast),
             .optimize => |x| c.Z3_optimize_assert(m.ctx.inner, x, ast.ast),
         }
     }
 
-    pub fn check(m: Model) SatResult {
+    pub fn check(m: *const Model) SatResult {
         return @enumFromInt(switch (m.inner) {
             .solver => |x| c.Z3_solver_check(m.ctx.inner, x),
             .optimize => |x| c.Z3_optimize_check(m.ctx.inner, x, 0, null),
         });
     }
 
-    pub fn constant(m: Model, comptime tag: AstKind, name: ?[:0]const u8, args: anytype) tag.Type() {
+    pub fn constant(m: *Model, comptime tag: AstKind, name: ?[:0]const u8, args: anytype) tag.Data() {
         const sort = m.ctx.getSort(tag, args);
-        const sym = Symbol.asZ3(.{ .string = name }, m.ctx);
-        const ast = c.Z3_mk_const(m.ctx.inner, sym, sort);
+        const sym = Symbol.asZ3(.{ .string = name }, &m.ctx);
+        const ast = c.Z3_mk_const(m.ctx.inner, sym, sort.inner);
         c.Z3_inc_ref(m.ctx.inner, ast);
-        return .{ .ctx = m.ctx, .ast = ast };
+        return .{ .ctx = &m.ctx, .ast = ast };
     }
 
-    pub fn int64(m: Model, i: i64) Int {
+    pub fn fromInt64(m: *Model, i: i64) Int {
         const sort = m.ctx.getSort(.int, .{});
-        const ast = c.Z3_mk_int64(m.ctx.inner, i, sort);
+        const ast = c.Z3_mk_int64(m.ctx.inner, i, sort.inner);
         c.Z3_inc_ref(m.ctx.inner, ast);
-        return .{ .ctx = m.ctx, .ast = ast };
+        return .{ .ctx = &m.ctx, .ast = ast };
     }
 
-    pub fn bvFromInt64(m: Model, i: i64, sz: u32) Bitvector {
+    pub fn bvFromInt64(m: *Model, i: i64, sz: u32) Bitvector {
         const sort = m.ctx.getSort(.bv, .{sz});
-        const ast = c.Z3_mk_int64(m.ctx.inner, i, sort);
+        const ast = c.Z3_mk_int64(m.ctx.inner, i, sort.inner);
         c.Z3_inc_ref(m.ctx.inner, ast);
-        return .{ .ctx = m.ctx, .ast = ast };
+        return .{ .ctx = &m.ctx, .ast = ast };
     }
 
-    fn makeSort(m: Model, comptime func: @TypeOf(c.Z3_mk_bool_sort)) Sort {
-        const sort = func(m.ctx.inner);
-        c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
+    pub fn boolean(m: *Model) Sort {
+        return m.ctx.getSort(.bool, .{});
     }
 
-    pub fn boolean(m: Model) Sort {
-        return m.makeSort(c.Z3_mk_bool_sort);
+    pub fn int(m: *Model) Sort {
+        return m.ctx.getSort(.int, .{});
     }
 
-    pub fn int(m: Model) Sort {
-        return m.makeSort(c.Z3_mk_int_sort);
+    pub fn real(m: *Model) Sort {
+        return m.ctx.getSort(.real, .{});
     }
 
-    pub fn real(m: Model) Sort {
-        return m.makeSort(c.Z3_mk_real_sort);
+    /// T must be a floating point type
+    pub fn float(m: *Model, comptime T: type) Sort {
+        const ebits: c_uint = std.math.floatExponentBits(T);
+        const sbits: c_uint = std.math.floatMantissaBits(T) + 1;
+        if (@typeInfo(T) != .float) @compileError("expected floating point type. found '" ++ @typeName(T) ++ "'");
+        switch (T) {
+            f32 => {
+                comptime std.debug.assert(ebits == 8 and sbits == 24);
+                return m.ctx.getSortByName(.float32, "Z3_mk_fpa_sort", .{ ebits, sbits });
+            },
+            f64 => {
+                comptime std.debug.assert(ebits == 11 and sbits == 53);
+                return m.ctx.getSortByName(.float64, "Z3_mk_fpa_sort", .{ ebits, sbits });
+            },
+            else => return m.ctx.getSortByName(.float, "Z3_mk_fpa_sort", .{ ebits, sbits }),
+        }
     }
 
-    pub fn float(m: Model, ebits: u32, sbits: u32) Sort {
-        const sort = c.Z3_mk_fpa_sort(m.ctx.inner, ebits, sbits);
-        c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
-    }
-
-    pub fn float32(m: Model) Sort {
-        const sort = c.Z3_mk_fpa_sort(m.ctx.inner, 8, 24);
-        c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
-    }
-
-    pub fn double(m: Model) Sort {
-        const sort = c.Z3_mk_fpa_sort(m.ctx.inner, 11, 53);
-        c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
-    }
-
-    pub fn string(m: Model) Sort {
-        return m.makeSort(c.Z3_mk_string_sort);
+    pub fn string(m: *Model) Sort {
+        return m.ctx.getSort(.string, .{});
     }
 
     pub fn bv(m: Model, sz: u32) Sort {
         const sort = c.Z3_mk_bv_sort(m.ctx.inner, sz);
         c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
+        return .{ .ctx = &m.ctx, .inner = sort };
     }
 
-    pub fn array(m: Model, domain: Sort, range: Sort) Sort {
+    pub fn array(m: *Model, domain: Sort, range: Sort) Sort {
         const sort = c.Z3_mk_array_sort(m.ctx.inner, domain.z3_sort, range.z3_sort);
         c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
+        return .{ .ctx = &m.ctx, .inner = sort };
     }
 
-    pub fn set(m: Model, elt: *const Sort) Sort {
+    pub fn set(m: *Model, elt: Sort) Sort {
         const sort = c.Z3_mk_set_sort(m.ctx.inner, elt.z3_sort);
         c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
+        return .{ .ctx = &m.ctx, .inner = sort };
     }
 
-    pub fn seq(m: Model, elt: *const Sort) Sort {
+    pub fn seq(m: *Model, elt: Sort) Sort {
         const sort = c.Z3_mk_seq_sort(m.ctx.inner, elt.z3_sort);
         c.Z3_inc_ref(m.ctx.inner, sort);
-        return .{ .ctx = m.ctx, .inner = sort };
+        return .{ .ctx = &m.ctx, .inner = sort };
     }
 
     pub fn getReasonUnknown(m: Model) ?[*:0]const u8 {
@@ -472,14 +570,14 @@ pub const Model = struct {
 };
 
 pub const PartialModel = struct {
-    ctx: Context,
+    ctx: *const Context,
     inner: c.Z3_model,
 
-    pub fn deinit(m: PartialModel) void {
+    pub fn deinit(m: *const PartialModel) void {
         c.Z3_model_dec_ref(m.ctx.inner, m.inner);
     }
 
-    pub fn eval(m: PartialModel, ast: anytype, model_completion: bool) ?@TypeOf(ast) {
+    pub fn eval(m: *const PartialModel, ast: anytype, model_completion: bool) ?@TypeOf(ast) {
         var ret = ast;
         if (c.Z3_model_eval(
             m.ctx.inner,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -139,118 +139,116 @@ pub const SortKind = enum(c_uint) {
     }
 };
 
-const A = Ast;
-
 pub const Bool = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 
-    pub const @"and" = A.@"and";
-    pub const @"or" = A.@"or";
+    pub const @"and" = Ast.@"and";
+    pub const @"or" = Ast.@"or";
 
-    pub const xor = A.xor;
-    pub const iff = A.iff;
-    pub const implies = A.implies;
+    pub const xor = Ast.xor;
+    pub const iff = Ast.iff;
+    pub const implies = Ast.implies;
 
-    pub const not = A.not;
-    pub const ite = A.ite;
+    pub const not = Ast.not;
+    pub const ite = Ast.ite;
 };
 pub const Int = struct {
     // storing ctx allows a builder pattern. i.e. `x.div(y)`
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 
-    pub const add = A.add;
-    pub const sub = A.sub;
-    pub const mul = A.mul;
+    pub const add = Ast.add;
+    pub const sub = Ast.sub;
+    pub const mul = Ast.mul;
 
-    pub const div = A.div;
-    pub const rem = A.rem;
-    pub const modulo = A.modulo;
-    pub const power = A.power;
-    pub const lt = A.lt;
-    pub const le = A.le;
-    pub const gt = A.gt;
-    pub const ge = A.ge;
+    pub const div = Ast.div;
+    pub const rem = Ast.rem;
+    pub const modulo = Ast.modulo;
+    pub const power = Ast.power;
+    pub const lt = Ast.lt;
+    pub const le = Ast.le;
+    pub const gt = Ast.gt;
+    pub const ge = Ast.ge;
 
-    pub const asInt64 = A.asInt64;
+    pub const asInt64 = Ast.asInt64;
 };
 pub const Real = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 };
 pub const Float = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 };
 pub const Bitvector = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 
-    pub const bvadd = A.bvadd;
-    pub const bvsub = A.bvsub;
-    pub const bvmul = A.bvmul;
-    pub const bvudiv = A.bvudiv;
-    pub const bvsdiv = A.bvsdiv;
-    pub const bvurem = A.bvurem;
-    pub const bvsrem = A.bvsrem;
-    pub const bvsmod = A.bvsmod;
-    pub const bvult = A.bvult;
-    pub const bvslt = A.bvslt;
-    pub const bvule = A.bvule;
-    pub const bvsle = A.bvsle;
-    pub const bvuge = A.bvuge;
-    pub const bvsge = A.bvsge;
-    pub const bvugt = A.bvugt;
-    pub const bvsgt = A.bvsgt;
+    pub const bvadd = Ast.bvadd;
+    pub const bvsub = Ast.bvsub;
+    pub const bvmul = Ast.bvmul;
+    pub const bvudiv = Ast.bvudiv;
+    pub const bvsdiv = Ast.bvsdiv;
+    pub const bvurem = Ast.bvurem;
+    pub const bvsrem = Ast.bvsrem;
+    pub const bvsmod = Ast.bvsmod;
+    pub const bvult = Ast.bvult;
+    pub const bvslt = Ast.bvslt;
+    pub const bvule = Ast.bvule;
+    pub const bvsle = Ast.bvsle;
+    pub const bvuge = Ast.bvuge;
+    pub const bvsge = Ast.bvsge;
+    pub const bvugt = Ast.bvugt;
+    pub const bvsgt = Ast.bvsgt;
 
-    pub const asInt64 = A.asInt64;
+    pub const asInt64 = Ast.asInt64;
 };
 pub const Array = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 
-    pub const select = A.select;
-    pub const store = A.store;
-    pub const asSet = A.asSet;
+    pub const select = Ast.select;
+    pub const store = Ast.store;
+    pub const asSet = Ast.asSet;
 };
 pub const Set = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 };
 pub const Seq = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
+    pub const toString = Ast.toString;
 };
 pub const Dynamic = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
-    pub const toString = A.toString;
-    pub const eq = A.eq;
+    pub const toString = Ast.toString;
+    pub const eq = Ast.eq;
 
     pub fn sortKind(self: Dynamic) SortKind {
         return @enumFromInt(c.Z3_get_sort_kind(
@@ -279,226 +277,222 @@ pub const Dynamic = struct {
     }
 };
 
-// zig fmt: off
 const Ast = struct {
-        pub fn deinit(self: anytype) void {
-            c.Z3_dec_ref(self.ctx.inner, self.ast);
-        }
-        pub fn toString(self: anytype) ?[]const u8 {
-            return if (c.Z3_ast_to_string(self.ctx.inner, self.ast)) |s| std.mem.sliceTo(s, 0) else null;
-        }
+    pub fn deinit(self: anytype) void {
+        c.Z3_dec_ref(self.ctx.inner, self.ast);
+    }
+    pub fn toString(self: anytype) ?[]const u8 {
+        return if (c.Z3_ast_to_string(self.ctx.inner, self.ast)) |s| std.mem.sliceTo(s, 0) else null;
+    }
 
-        inline fn verify(comptime ok: bool, T: type, comptime message: []const u8) void {
-            comptime if (!ok)
-                @compileError(std.fmt.comptimePrint(message ++ ".  found '{s}'", .{@typeName(T)}));
-        }
-        inline fn Child(T: type) type {
-            return switch (@typeInfo(T)) {
-                .pointer => |p| p.child,
-                else => T,
-            };
-        }
-        fn binopAny(R: type, lhs: anytype, rhs: anytype, func: @TypeOf(c.Z3_mk_div)) R {
-            const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
-            c.Z3_inc_ref(lhs.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = lhs.ctx };
-        }
-        fn binop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
-            return binopAny(R, lhs, rhs, func);
-        }
-        fn varop(R: type, lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) R {
-            var buf: [16]c.Z3_ast = undefined;
-            if (buf.len < rhss.len + 1) @panic("varop only supports up to 15 rhs args.");
-            buf[0] = lhs.ast;
-            for (0..rhss.len) |i| buf[i + 1] = rhss[i].ast;
-            const ast = func(lhs.ctx.inner, @intCast(rhss.len + 1), &buf);
-            c.Z3_inc_ref(lhs.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = lhs.ctx };
-        }
+    inline fn verify(comptime ok: bool, T: type, comptime message: []const u8) void {
+        comptime if (!ok)
+            @compileError(std.fmt.comptimePrint(message ++ ".  found '{s}'", .{@typeName(T)}));
+    }
+    inline fn Child(T: type) type {
+        return switch (@typeInfo(T)) {
+            .pointer => |p| p.child,
+            else => T,
+        };
+    }
+    fn binopAny(R: type, lhs: anytype, rhs: anytype, func: @TypeOf(c.Z3_mk_div)) R {
+        const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
+        c.Z3_inc_ref(lhs.ctx.inner, ast);
+        return .{ .ast = ast, .ctx = lhs.ctx };
+    }
+    fn binop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
+        return binopAny(R, lhs, rhs, func);
+    }
+    fn varop(R: type, lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) R {
+        var buf: [16]c.Z3_ast = undefined;
+        if (buf.len < rhss.len + 1) @panic("varop only supports up to 15 rhs args.");
+        buf[0] = lhs.ast;
+        for (0..rhss.len) |i| buf[i + 1] = rhss[i].ast;
+        const ast = func(lhs.ctx.inner, @intCast(rhss.len + 1), &buf);
+        c.Z3_inc_ref(lhs.ctx.inner, ast);
+        return .{ .ast = ast, .ctx = lhs.ctx };
+    }
 
-        // *** Numeric ops ***
-        inline fn verifyNumeric(T: type) void {
-            verify(T == Int or T == Float or T == Real, T, "expected numeric type");
-        }
-        fn numericBinop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
-            verifyNumeric(Child(@TypeOf(lhs)));
-            return binop(R, lhs, rhs, func);
-        }
-        fn numericVarop(lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) Child(@TypeOf(lhs)) {
-            verifyNumeric(Child(@TypeOf(lhs)));
-            return varop(Child(@TypeOf(lhs)), lhs, rhss, func);
-        }
+    // *** Numeric ops ***
+    inline fn verifyNumeric(T: type) void {
+        verify(T == Int or T == Float or T == Real, T, "expected numeric type");
+    }
+    fn numericBinop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
+        verifyNumeric(Child(@TypeOf(lhs)));
+        return binop(R, lhs, rhs, func);
+    }
+    fn numericVarop(lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) Child(@TypeOf(lhs)) {
+        verifyNumeric(Child(@TypeOf(lhs)));
+        return varop(Child(@TypeOf(lhs)), lhs, rhss, func);
+    }
 
-        pub fn div(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_div);
-        }
-        pub fn rem(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_rem);
-        }
-        pub fn mod(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_mod);
-        }
-        pub fn power(lhs: anytype, rhs: Child(@TypeOf(lhs))) Real {
-            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_power);
-        }
+    pub fn div(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+        return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_div);
+    }
+    pub fn rem(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+        return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_rem);
+    }
+    pub fn mod(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+        return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_mod);
+    }
+    pub fn power(lhs: anytype, rhs: Child(@TypeOf(lhs))) Real {
+        return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_power);
+    }
 
-        pub fn lt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
-            return numericBinop(Bool, lhs, rhs, c.Z3_mk_lt);
-        }
-        pub fn le(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
-            return numericBinop(Bool, lhs, rhs, c.Z3_mk_le);
-        }
-        pub fn gt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
-            return numericBinop(Bool, lhs, rhs, c.Z3_mk_gt);
-        }
-        pub fn ge(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
-            return numericBinop(Bool, lhs, rhs, c.Z3_mk_ge);
-        }
-        pub fn eq(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
-            return binop(Bool, lhs, rhs, c.Z3_mk_eq);
-        }
+    pub fn lt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+        return numericBinop(Bool, lhs, rhs, c.Z3_mk_lt);
+    }
+    pub fn le(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+        return numericBinop(Bool, lhs, rhs, c.Z3_mk_le);
+    }
+    pub fn gt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+        return numericBinop(Bool, lhs, rhs, c.Z3_mk_gt);
+    }
+    pub fn ge(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+        return numericBinop(Bool, lhs, rhs, c.Z3_mk_ge);
+    }
+    pub fn eq(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
+        return binop(Bool, lhs, rhs, c.Z3_mk_eq);
+    }
 
-        pub fn add(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-            return numericVarop(lhs, rhss, c.Z3_mk_add);
-        }
+    pub fn add(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+        return numericVarop(lhs, rhss, c.Z3_mk_add);
+    }
+    pub fn sub(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+        return numericVarop(lhs, rhss, c.Z3_mk_sub);
+    }
+    pub fn mul(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+        return numericVarop(lhs, rhss, c.Z3_mk_mul);
+    }
 
-        pub fn sub(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-            return numericVarop(lhs, rhss, c.Z3_mk_sub);
-        }
+    pub fn asInt64(lhs: anytype) ?i64 {
+        var ret: i64 = undefined;
+        return if (c.Z3_get_numeral_int64(lhs.ctx.inner, lhs.ast, &ret))
+            ret
+        else
+            null;
+    }
 
-        pub fn mul(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-            return numericVarop(lhs, rhss, c.Z3_mk_mul);
-        }
+    // *** Bitvector ops ***
+    fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
+        return binop(R, lhs, rhs, func);
+    }
 
-        pub fn asInt64(lhs: anytype) ?i64 {
-            var ret: i64 = undefined;
-            return if (c.Z3_get_numeral_int64(lhs.ctx.inner, lhs.ast, &ret))
-                ret
-            else
-                null;
-        }
+    /// Addition
+    pub fn bvadd(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvadd);
+    }
+    /// Subtraction
+    pub fn bvsub(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsub);
+    }
+    /// Multiplication
+    pub fn bvmul(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvmul);
+    }
+    /// Unsigned division
+    pub fn bvudiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvudiv);
+    }
+    /// Signed division
+    pub fn bvsdiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsdiv);
+    }
+    /// Unsigned remainder
+    pub fn bvurem(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvurem);
+    }
+    /// Signed remainder (sign follows dividend)
+    pub fn bvsrem(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsrem);
+    }
+    /// Signed remainder (sign follows divisor)
+    pub fn bvsmod(lhs: Bitvector, rhs: Bitvector) Bitvector {
+        return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsmod);
+    }
 
-        // *** Bitvector ops ***
-        fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
-            return binop(R, lhs, rhs, func);
-        }
+    /// Unsigned less than
+    pub fn bvult(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvult);
+    }
+    /// Signed less than
+    pub fn bvslt(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvslt);
+    }
+    /// Unsigned less than or equal
+    pub fn bvule(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvule);
+    }
+    /// Signed less than or equal
+    pub fn bvsle(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsle);
+    }
+    /// Unsigned greater or equal
+    pub fn bvuge(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvuge);
+    }
+    /// Signed greater or equal
+    pub fn bvsge(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsge);
+    }
+    /// Unsigned greater than
+    pub fn bvugt(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvugt);
+    }
+    /// Signed greater than
+    pub fn bvsgt(lhs: Bitvector, rhs: Bitvector) Bool {
+        return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsgt);
+    }
 
-        /// Addition
-        pub fn bvadd(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvadd);
-        }
-        /// Subtraction
-        pub fn bvsub(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsub);
-        }
-        /// Multiplication
-        pub fn bvmul(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvmul);
-        }
-        /// Unsigned division
-        pub fn bvudiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvudiv);
-        }
-        /// Signed division
-        pub fn bvsdiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsdiv);
-        }
-        /// Unsigned remainder
-        pub fn bvurem(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvurem);
-        }
-        /// Signed remainder (sign follows dividend)
-        pub fn bvsrem(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsrem);
-        }
-        /// Signed remainder (sign follows divisor)
-        pub fn bvsmod(lhs: Bitvector, rhs: Bitvector) Bitvector {
-            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsmod);
-        }
+    // *** Array ops ***
+    pub fn select(lhs: anytype, rhs: anytype) Dynamic {
+        return binopAny(Dynamic, lhs, rhs, c.Z3_mk_select);
+    }
+    pub fn store(lhs: anytype, index: Int, value: anytype) Child(@TypeOf(lhs)) {
+        const ast = c.Z3_mk_store(
+            lhs.ctx.inner,
+            lhs.ast,
+            index.ast,
+            value.ast,
+        );
+        c.Z3_inc_ref(lhs.ctx.inner, ast);
+        return .{ .ast = ast, .ctx = lhs.ctx };
+    }
 
-        /// Unsigned less than
-        pub fn bvult(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvult);
-        }
-        /// Signed less than
-        pub fn bvslt(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvslt);
-        }
-        /// Unsigned less than or equal
-        pub fn bvule(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvule);
-        }
-        /// Signed less than or equal
-        pub fn bvsle(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsle);
-        }
-        /// Unsigned greater or equal
-        pub fn bvuge(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvuge);
-        }
-        /// Signed greater or equal
-        pub fn bvsge(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsge);
-        }
-        /// Unsigned greater than
-        pub fn bvugt(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvugt);
-        }
-        /// Signed greater than
-        pub fn bvsgt(lhs: Bitvector, rhs: Bitvector) Bool {
-            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsgt);
-        }
+    // *** Bool ops ***
+    pub fn @"and"(lhs: Bool, rhss: []const Bool) Bool {
+        return varop(Bool, lhs, rhss, c.Z3_mk_and);
+    }
+    pub fn @"or"(lhs: Bool, rhss: []const Bool) Bool {
+        return varop(Bool, lhs, rhss, c.Z3_mk_or);
+    }
 
-        // *** Array ops ***
-        pub fn select(lhs: anytype, rhs: anytype) Dynamic {
-            return binopAny(Dynamic, lhs, rhs, c.Z3_mk_select);
-        }
-        pub fn store(lhs: anytype, index: Int, value: anytype) Child(@TypeOf(lhs)) {
-            const ast = c.Z3_mk_store(
-                lhs.ctx.inner,
-                lhs.ast,
-                index.ast,
-                value.ast,
-            );
-            c.Z3_inc_ref(lhs.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = lhs.ctx };
-        }
+    pub fn xor(lhs: Bool, rhs: Bool) Bool {
+        return binop(Bool, lhs, rhs, c.Z3_mk_xor);
+    }
+    pub fn iff(lhs: Bool, rhs: Bool) Bool {
+        return binop(Bool, lhs, rhs, c.Z3_mk_iff);
+    }
+    pub fn implies(lhs: Bool, rhs: Bool) Bool {
+        return binop(Bool, lhs, rhs, c.Z3_mk_implies);
+    }
 
-        // *** Bool ops ***
-        pub fn @"and"(lhs: Bool, rhss: []const Bool) Bool {
-            return varop(Bool, lhs, rhss, c.Z3_mk_and);
-        }
-        pub fn @"or"(lhs: Bool, rhss: []const Bool) Bool {
-            return varop(Bool, lhs, rhss, c.Z3_mk_or);
-        }
+    pub fn not(op: Bool) Bool {
+        const ast = c.Z3_mk_not(op.ctx.inner, op.ast);
+        c.Z3_inc_ref(op.ctx.inner, ast);
+        return .{ .ast = ast, .ctx = op.ctx };
+    }
 
-        pub fn xor(lhs: Bool, rhs: Bool) Bool {
-            return binop(Bool, lhs, rhs, c.Z3_mk_xor);
-        }
-        pub fn iff(lhs: Bool, rhs: Bool) Bool {
-            return binop(Bool, lhs, rhs, c.Z3_mk_iff);
-        }
-        pub fn implies(lhs: Bool, rhs: Bool) Bool {
-            return binop(Bool, lhs, rhs, c.Z3_mk_implies);
-        }
-
-        pub fn not(op: Bool) Bool {
-            const ast = c.Z3_mk_not(op.ctx.inner, op.ast);
-            c.Z3_inc_ref(op.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = op.ctx };
-        }
-
-        /// Create an AST node representing an if-then-else. If `predicate` is true,
-        /// the node results in `lhs`, otherwise it results in `rhs`.
-        ///
-        /// `rhs` and `lhs` must be the same sort, and the result type is that sort.
-        pub fn ite(predicate: Bool, lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
-            const ast = c.Z3_mk_ite(predicate.ctx.inner, predicate.ast, lhs.ast, rhs.ast);
-            c.Z3_inc_ref(predicate.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = predicate.ctx };
-        }
+    /// Create an AST node representing an if-then-else. If `predicate` is true,
+    /// the node results in `lhs`, otherwise it results in `rhs`.
+    ///
+    /// `rhs` and `lhs` must be the same sort, and the result type is that sort.
+    pub fn ite(predicate: Bool, lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+        const ast = c.Z3_mk_ite(predicate.ctx.inner, predicate.ast, lhs.ast, rhs.ast);
+        c.Z3_inc_ref(predicate.ctx.inner, ast);
+        return .{ .ast = ast, .ctx = predicate.ctx };
+    }
 };
-// zig fmt: on
 
 pub const Symbol = union(enum) {
     int: i32,

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,264 +1,476 @@
 const std = @import("std");
-const z3 = @import("z3");
+const c = @import("z3");
+const assert = std.debug.assert;
 
-pub const Sort = enum {
-    int,
-    bool,
-    real,
+fn errorHandler(ctx: c.Z3_context, e: c.Z3_error_code) callconv(.c) void {
+    std.debug.print("Error #{}: {s}\nIncorrect use of Z3.\n", .{ e, c.Z3_get_error_msg(ctx, e) });
+    std.process.exit(1);
+}
 
-    fn Data(s: Sort) type {
-        return switch (s) {
-            .int => Int,
-            .bool => Bool,
-            .real => Real,
-        };
-    }
-};
+pub const Context = struct {
+    inner: c.Z3_context,
+    /// stored on the heap to keep Context small and copyable
+    cached_sorts: *CachedSorts,
 
-pub const Prover = enum {
-    solver,
-    optimize,
-};
+    /// sorts that can be cached whose mk_*_sort method has one argument
+    const CachedSorts = struct {
+        bool: ?c.Z3_sort = null,
+        int: ?c.Z3_sort = null,
+        real: ?c.Z3_sort = null,
+        float32: ?c.Z3_sort = null,
+        double: ?c.Z3_sort = null,
+        string: ?c.Z3_sort = null,
+    };
 
-pub const Check = enum(i2) {
-    /// Unsatisfiable
-    false = -1,
-    /// Unknown
-    undef = 0,
-    /// Satisfiable
-    true = 1,
-};
+    pub const ConfigKvs = []const [2][:0]const u8;
 
-pub const Int = extern struct {
-    ast: z3.Z3_ast,
-};
-
-pub const Real = extern struct {
-    ast: z3.Z3_ast,
-};
-
-pub const Bool = extern struct {
-    ast: z3.Z3_ast,
-};
-
-pub const Model = struct {
-    cfg: z3.Z3_config,
-    ctx: z3.Z3_context,
-    /// Stored initialized types and caches them for use later.
-    sorts: std.enums.EnumFieldStruct(
-        Sort,
-        ?z3.Z3_sort,
-        @as(?z3.Z3_sort, null),
-    ),
-    prover: union(Prover) {
-        solver: z3.Z3_solver,
-        optimize: z3.Z3_optimize,
-    },
-
-    pub fn init(comptime p: Prover) Model {
-        const cfg = z3.Z3_mk_config();
-        const ctx = z3.Z3_mk_context(cfg);
-        return .{
-            .cfg = cfg,
-            .ctx = ctx,
-            .sorts = .{},
-            .prover = @unionInit(@FieldType(Model, "prover"), @tagName(p), switch (p) {
-                .solver => s: {
-                    const solver = z3.Z3_mk_solver(ctx);
-                    z3.Z3_solver_inc_ref(ctx, solver);
-                    break :s solver;
-                },
-                .optimize => o: {
-                    const optimize = z3.Z3_mk_optimize(ctx);
-                    z3.Z3_optimize_inc_ref(ctx, optimize);
-                    break :o optimize;
-                },
-            }),
-        };
-    }
-
-    pub fn deinit(m: *Model) void {
-        switch (m.prover) {
-            .solver => |s| z3.Z3_solver_dec_ref(m.ctx, s),
-            .optimize => |o| z3.Z3_optimize_dec_ref(m.ctx, o),
+    pub fn init(allocator: std.mem.Allocator, kvs: ConfigKvs) !Context {
+        const cfg = c.Z3_mk_config();
+        defer c.Z3_del_config(cfg);
+        for (kvs) |kv| {
+            c.Z3_set_param_value(cfg, kv[0].ptr, kv[1].ptr);
         }
-        z3.Z3_del_context(m.ctx);
-        z3.Z3_del_config(m.cfg);
+        const inner = c.Z3_mk_context_rc(cfg);
+        c.Z3_set_error_handler(inner, errorHandler);
+        const cached_sorts = try allocator.create(CachedSorts);
+        cached_sorts.* = .{};
+        return .{ .inner = inner, .cached_sorts = cached_sorts };
     }
 
-    fn getSort(m: *Model, comptime s: Sort) z3.Z3_sort {
-        return @field(m.sorts, @tagName(s)) orelse {
-            const sort = @field(z3, "Z3_mk_" ++ @tagName(s) ++ "_sort")(m.ctx);
-            @field(m.sorts, @tagName(s)) = sort;
+    pub fn deinit(ctx: Context, allocator: std.mem.Allocator) void {
+        allocator.destroy(ctx.cached_sorts);
+        c.Z3_del_context(ctx.inner);
+    }
+
+    fn getSort(ctx: Context, comptime tag: AstKind, args: anytype) c.Z3_sort {
+        if (@hasField(CachedSorts, @tagName(tag))) {
+            comptime assert(args.len == 0);
+            if (@field(ctx.cached_sorts, @tagName(tag))) |sort| return sort;
+            const sort = @field(c, "Z3_mk_" ++ @tagName(tag) ++ "_sort")(ctx.inner);
+            c.Z3_inc_ref(ctx.inner, c.Z3_sort_to_ast(ctx.inner, sort));
+            @field(ctx.cached_sorts, @tagName(tag)) = sort;
             return sort;
-        };
-    }
-
-    fn gatherAst(args: anytype) [args.len]z3.Z3_ast {
-        const len = args.len;
-        var ast: [len]z3.Z3_ast = undefined;
-        inline for (args, 0..) |arg, i| ast[i] = arg.ast;
-        return ast;
-    }
-
-    fn Coerced(args: type) type {
-        const info = @typeInfo(args);
-        if (info != .pointer) @compileError("expected either a pointer to tuple or slice");
-        if (info == .pointer and info.pointer.size == .slice) {
-            return args;
-        } else {
-            const first = @typeInfo(std.meta.Child(args)).@"struct".fields[0];
-            return []const first.type;
         }
+
+        const sort = @call(.auto, @field(c, "Z3_mk_" ++ @tagName(tag) ++ "_sort"), .{ctx.inner} ++ args);
+        c.Z3_inc_ref(ctx.inner, c.Z3_sort_to_ast(ctx.inner, sort));
+        return sort;
+    }
+};
+
+pub const AstKind = enum {
+    bool,
+    int,
+    real,
+    float,
+    float32,
+    double,
+    string,
+    bv,
+    array,
+    set,
+    seq,
+
+    fn Type(tag: AstKind) type {
+        return switch (tag) {
+            .bool => Bool,
+            .int => Int,
+            .real => Real,
+            .float => Float,
+            .float32 => Float32,
+            .double => Double,
+            .string => String,
+            .bv => Bitvector,
+            .array => Array,
+            .set => Set,
+            .seq => Seq,
+        };
     }
 
-    /// Note that this function uses `Z3_mk_fresh_const` instead of `Z3_mk_const`.
-    pub fn constant(m: *Model, comptime s: Sort, name: ?[:0]const u8) s.Data() {
-        const sort = m.getSort(s);
-        return .{ .ast = z3.Z3_mk_fresh_const(m.ctx, name orelse null, sort) };
+    pub fn isNumeric(tag: AstKind) bool {
+        return switch (tag) {
+            .int,
+            .real,
+            .float,
+            .float32,
+            .double,
+            => true,
+            else => false,
+        };
     }
+};
 
-    pub fn int(m: *Model, value: i32) Int {
-        return .{ .ast = z3.Z3_mk_int(m.ctx, value, m.getSort(.int)) };
-    }
+pub const Bool = Ast(struct {
+    pub const ast_kind: AstKind = .bool;
+});
+pub const Int = Ast(struct {
+    pub const ast_kind: AstKind = .int;
+});
+pub const Real = Ast(struct {
+    pub const ast_kind: AstKind = .real;
+});
+pub const Float = Ast(struct {
+    pub const ast_kind: AstKind = .float;
+});
+pub const Float32 = Ast(struct {
+    pub const ast_kind: AstKind = .float32;
+});
+pub const Double = Ast(struct {
+    pub const ast_kind: AstKind = .double;
+});
+pub const String = Ast(struct {
+    pub const ast_kind: AstKind = .string;
+});
+pub const Bitvector = Ast(struct {
+    pub const ast_kind: AstKind = .bv;
+});
+pub const Array = Ast(struct {
+    pub const ast_kind: AstKind = .array;
+});
+pub const Set = Ast(struct {
+    pub const ast_kind: AstKind = .set;
+});
+pub const Seq = Ast(struct {
+    pub const ast_kind: AstKind = .seq;
+});
 
-    pub fn @"true"(m: *Model) Bool {
-        return .{ .ast = z3.Z3_mk_true(m.ctx) };
-    }
+comptime {
+    assert(Bool != Int);
+}
 
-    /// Creates an addition AST node.
-    /// All arguments must be the same sort, being either int or real.
-    /// The return type will be that same sort.
-    pub fn add(m: *Model, args: anytype) std.meta.Child(Coerced(@TypeOf(args))) {
-        std.debug.assert(args.len > 0);
-        const coerced: Coerced(@TypeOf(args)) = args;
-        return .{ .ast = z3.Z3_mk_add(
-            m.ctx,
-            @intCast(args.len),
-            @as([*]const z3.Z3_ast, @ptrCast(coerced)),
-        ) };
-    }
+pub fn Ast(T: type) type {
+    return struct {
+        // store ctx to allow a builder pattern. i.e. `x.div(y)`
+        ctx: Context,
+        ast: c.Z3_ast,
 
-    /// Creates an multiplication AST node.
-    /// All arguments must be the same sort, being either int or real.
-    /// The return type will be that same sort.
-    pub fn mul(m: *Model, args: anytype) std.meta.Child(Coerced(@TypeOf(args))) {
-        std.debug.assert(args.len > 0);
-        const coerced: Coerced(@TypeOf(args)) = args;
-        return .{ .ast = z3.Z3_mk_mul(
-            m.ctx,
-            args.len,
-            @as([*]const z3.Z3_ast, @ptrCast(coerced)),
-        ) };
-    }
+        const Self = @This();
 
-    pub fn @"or"(m: *Model, args: []const Bool) Bool {
-        std.debug.assert(args.len > 0);
-        return .{ .ast = z3.Z3_mk_or(
-            m.ctx,
-            @intCast(args.len),
-            @as([*]const z3.Z3_ast, @ptrCast(args)),
-        ) };
-    }
-
-    pub fn not(m: *Model, op: Bool) Bool {
-        return .{ .ast = z3.Z3_mk_not(m.ctx, op.ast) };
-    }
-
-    /// Creates an AST node that implies when `lhs` is true, `rhs` must be true.
-    pub fn implies(m: *Model, lhs: Bool, rhs: Bool) Bool {
-        return .{ .ast = z3.Z3_mk_implies(m.ctx, lhs.ast, rhs.ast) };
-    }
-
-    /// Create an AST node representing an if-then-else. If `predicate` is true,
-    /// the node results in `lhs`, otherwise it results in `rhs`.
-    ///
-    /// `rhs` and `lhs` must be the same sort, and the result type is that sort.
-    pub fn ite(m: *Model, predicate: Bool, lhs: anytype, rhs: anytype) @TypeOf(lhs) {
-        comptime std.debug.assert(@TypeOf(lhs) == @TypeOf(rhs));
-        return .{ .ast = z3.Z3_mk_ite(m.ctx, predicate.ast, lhs.ast, rhs.ast) };
-    }
-
-    /// Create an AST node representing `lhs = rhs`.
-    /// The nodes `lhs` and `rhs` must have the same type.
-    pub fn eq(m: *Model, lhs: anytype, rhs: anytype) Bool {
-        comptime std.debug.assert(@TypeOf(lhs) == @TypeOf(rhs));
-        return .{ .ast = z3.Z3_mk_eq(m.ctx, lhs.ast, rhs.ast) };
-    }
-
-    /// Create an AST node representing `lhs <= rhs`.
-    /// The nodes `lhs` and `rhs` must have the same type.
-    pub fn le(m: *Model, lhs: anytype, rhs: anytype) Bool {
-        comptime std.debug.assert(@TypeOf(lhs) == @TypeOf(rhs));
-        return .{ .ast = z3.Z3_mk_le(m.ctx, lhs.ast, rhs.ast) };
-    }
-
-    pub fn iff(m: *Model, lhs: Bool, rhs: Bool) Bool {
-        return .{ .ast = z3.Z3_mk_iff(m.ctx, lhs.ast, rhs.ast) };
-    }
-
-    /// Assert a constraint into the solver.
-    pub fn assert(m: *Model, constraint: anytype) void {
-        switch (m.prover) {
-            .solver => |s| z3.Z3_solver_assert(m.ctx, s, constraint.ast),
-            .optimize => |o| z3.Z3_optimize_assert(m.ctx, o, constraint.ast),
+        pub fn deinit(self: Self) void {
+            c.Z3_dec_ref(self.ctx.inner, self.ast);
         }
+
+        // *** Numeric ops ***
+        fn numericBinop(R: type, lhs: Self, rhs: Self, func: @TypeOf(c.Z3_mk_div)) R {
+            comptime if (!T.ast_kind.isNumeric()) unreachable;
+            const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
+            c.Z3_inc_ref(lhs.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = lhs.ctx };
+        }
+
+        pub fn div(lhs: Self, rhs: Self) Self {
+            return numericBinop(Self, lhs, rhs, c.Z3_mk_div);
+        }
+        pub fn rem(lhs: Self, rhs: Self) Self {
+            return numericBinop(Self, lhs, rhs, c.Z3_mk_rem);
+        }
+        pub fn mod(lhs: Self, rhs: Self) Self {
+            return numericBinop(Self, lhs, rhs, c.Z3_mk_mod);
+        }
+        pub fn power(lhs: Self, rhs: Self) Real {
+            return numericBinop(Self, lhs, rhs, c.Z3_mk_power);
+        }
+
+        pub fn lt(lhs: Self, rhs: Self) Bool {
+            return numericBinop(Bool, lhs, rhs, c.Z3_mk_lt);
+        }
+        pub fn le(lhs: Self, rhs: Self) Bool {
+            return numericBinop(Bool, lhs, rhs, c.Z3_mk_le);
+        }
+        pub fn gt(lhs: Self, rhs: Self) Bool {
+            return numericBinop(Bool, lhs, rhs, c.Z3_mk_gt);
+        }
+        pub fn ge(lhs: Self, rhs: Self) Bool {
+            return numericBinop(Bool, lhs, rhs, c.Z3_mk_ge);
+        }
+        pub fn eq(lhs: Self, rhs: Self) Bool {
+            return numericBinop(Bool, lhs, rhs, c.Z3_mk_eq);
+        }
+
+        fn numericVarop(lhs: Self, rhss: []const Self, comptime func: @TypeOf(c.Z3_mk_add)) Self {
+            comptime if (!T.ast_kind.isNumeric()) unreachable;
+            var buf: [16]c.Z3_ast = undefined;
+            if (buf.len < rhss.len + 1) @panic("numericVarop only supports up to 15 rhs args.");
+            buf[0] = lhs.ast;
+            for (0..rhss.len) |i| buf[i + 1] = rhss[i].ast;
+            const ast = func(lhs.ctx.inner, @intCast(rhss.len + 1), &buf);
+            c.Z3_inc_ref(lhs.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = lhs.ctx };
+        }
+
+        pub fn add(lhs: Self, rhss: []const Self) Self {
+            return numericVarop(lhs, rhss, c.Z3_mk_add);
+        }
+
+        pub fn sub(lhs: Self, rhss: []const Self) Self {
+            return numericVarop(lhs, rhss, c.Z3_mk_sub);
+        }
+
+        pub fn mul(lhs: Self, rhss: []const Self) Self {
+            return numericVarop(lhs, rhss, c.Z3_mk_mul);
+        }
+
+        pub fn int64(ast: Self) ?i64 {
+            var ret: i64 = undefined;
+            return if (c.Z3_get_numeral_int64(ast.ctx.inner, ast.ast, &ret))
+                ret
+            else
+                null;
+        }
+
+        // *** Bitvector ops ***
+        fn bvBinop(R: type, lhs: Bitvector, rhs: Bitvector, func: @TypeOf(c.Z3_mk_bvadd)) R {
+            comptime if (T.ast_kind != .bv) unreachable;
+            const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
+            c.Z3_inc_ref(lhs.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = lhs.ctx };
+        }
+
+        /// Addition
+        pub fn bvadd(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvadd);
+        }
+        /// Subtraction
+        pub fn bvsub(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsub);
+        }
+        /// Multiplication
+        pub fn bvmul(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvmul);
+        }
+        /// Unsigned division
+        pub fn bvudiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvudiv);
+        }
+        /// Signed division
+        pub fn bvsdiv(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsdiv);
+        }
+        /// Unsigned remainder
+        pub fn bvurem(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvurem);
+        }
+        /// Signed remainder (sign follows dividend)
+        pub fn bvsrem(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsrem);
+        }
+        /// Signed remainder (sign follows divisor)
+        pub fn bvsmod(lhs: Bitvector, rhs: Bitvector) Bitvector {
+            return bvBinop(Bitvector, lhs, rhs, c.Z3_mk_bvsmod);
+        }
+
+        /// Unsigned less than
+        pub fn bvult(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvult);
+        }
+        /// Signed less than
+        pub fn bvslt(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvslt);
+        }
+        /// Unsigned less than or equal
+        pub fn bvule(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvule);
+        }
+        /// Signed less than or equal
+        pub fn bvsle(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsle);
+        }
+        /// Unsigned greater or equal
+        pub fn bvuge(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvuge);
+        }
+        /// Signed greater or equal
+        pub fn bvsge(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsge);
+        }
+        /// Unsigned greater than
+        pub fn bvugt(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvugt);
+        }
+        /// Signed greater than
+        pub fn bvsgt(lhs: Bitvector, rhs: Bitvector) Bool {
+            return bvBinop(Bool, lhs, rhs, c.Z3_mk_bvsgt);
+        }
+    };
+}
+
+pub const Symbol = union(enum) {
+    int: i32,
+    string: ?[:0]const u8,
+
+    pub const Tag = std.meta.Tag(Symbol);
+
+    fn asZ3(sym: Symbol, ctx: Context) c.Z3_symbol {
+        return switch (sym) {
+            .int => |i| c.Z3_mk_int_symbol(ctx.inner, i),
+            .string => |s| c.Z3_mk_string_symbol(ctx.inner, @ptrCast(s)),
+        };
+    }
+};
+
+pub const Sort = struct {
+    ctx: Context,
+    inner: c.Z3_sort,
+};
+
+pub const Solver = struct {
+    ctx: Context,
+    inner: c.Z3_solver,
+
+    pub fn initCtx(ctx: Context) Solver {
+        const inner = c.Z3_mk_solver(ctx.inner);
+        c.Z3_solver_inc_ref(ctx.inner, inner);
+        return .{ .ctx = ctx, .inner = inner };
     }
 
-    pub fn check(m: *Model) Check {
-        const result = switch (m.prover) {
-            .solver => |s| z3.Z3_solver_check(m.ctx, s),
-            .optimize => |o| z3.Z3_optimize_check(m.ctx, o, 0, null),
-        };
-        return @enumFromInt(result);
+    pub fn initConfig(allocator: std.mem.Allocator, config_kvs: Context.ConfigKvs) !Solver {
+        return .initCtx(try .init(allocator, config_kvs));
     }
 
-    pub fn minimize(m: *Model, objective: anytype) void {
-        _ = switch (m.prover) {
-            .solver => @panic("cannot minimze 'solver' prover"),
-            .optimize => |o| z3.Z3_optimize_minimize(m.ctx, o, objective.ast),
-        };
+    pub fn init(gpa: std.mem.Allocator) !Solver {
+        return initConfig(gpa, &.{.{ "proof", "true" }});
     }
 
-    /// The string is still owned by the model, it's stored in a temporary buffer inside and dies on `deinit()`.
-    pub fn toString(m: *const Model) []const u8 {
-        const str = switch (m.prover) {
-            .solver => |s| z3.Z3_solver_to_string(m.ctx, s),
-            .optimize => |o| z3.Z3_optimize_to_string(m.ctx, o),
-        };
-        return std.mem.sliceTo(str, 0);
+    pub fn deinit(s: Solver, allocator: std.mem.Allocator) void {
+        c.Z3_solver_dec_ref(s.ctx.inner, s.inner);
+        s.ctx.deinit(allocator);
     }
 
     /// Panics if
     /// 1. `check()` wasn't ran before calling `getLastModel()`.
     /// 2. The last `check()` call didn't return `true`.
-    pub fn getLastModel(m: *Model) PartialModel {
-        const model = switch (m.prover) {
-            .optimize => |o| z3.Z3_optimize_get_model(m.ctx, o),
-            .solver => @panic("TODO"),
-        };
-        z3.Z3_model_inc_ref(m.ctx, model);
-        return .{ .m = m, .raw = model };
+    pub fn getLastModel(s: Solver) Model {
+        const m = c.Z3_solver_get_model(s.ctx.inner, s.inner);
+        c.Z3_model_inc_ref(s.ctx.inner, m);
+        return .{ .ctx = s.ctx, .inner = m };
+    }
+
+    pub fn assert(s: Solver, ast: anytype) void {
+        c.Z3_solver_assert(s.ctx.inner, s.inner, ast.ast);
+    }
+
+    pub fn check(s: Solver) SatResult {
+        return @enumFromInt(c.Z3_solver_check(s.ctx.inner, s.inner));
+    }
+
+    pub fn constant(s: Solver, comptime tag: AstKind, name: ?[:0]const u8, args: anytype) tag.Type() {
+        const sort = s.ctx.getSort(tag, args);
+        const sym = Symbol.asZ3(.{ .string = name }, s.ctx);
+        const ast = c.Z3_mk_const(s.ctx.inner, sym, sort);
+        c.Z3_inc_ref(s.ctx.inner, ast);
+        return .{ .ctx = s.ctx, .ast = ast };
+    }
+
+    pub fn int64(s: Solver, i: i64) Int {
+        const sort = s.ctx.getSort(.int, .{});
+        const ast = c.Z3_mk_int64(s.ctx.inner, i, sort);
+        c.Z3_inc_ref(s.ctx.inner, ast);
+        return .{ .ctx = s.ctx, .ast = ast };
+    }
+
+    pub fn bvFromInt64(s: Solver, i: i64, sz: u32) Bitvector {
+        const sort = s.ctx.getSort(.bv, .{sz});
+        const ast = c.Z3_mk_int64(s.ctx.inner, i, sort);
+        c.Z3_inc_ref(s.ctx.inner, ast);
+        return .{ .ctx = s.ctx, .ast = ast };
+    }
+
+    fn makeSort(s: Solver, comptime func: @TypeOf(c.Z3_mk_bool_sort)) Sort {
+        const sort = func(s.ctx.inner);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
+    }
+
+    pub fn boolean(s: Solver) Sort {
+        return s.makeSort(c.Z3_mk_bool_sort);
+    }
+
+    pub fn int(s: Solver) Sort {
+        return s.makeSort(c.Z3_mk_int_sort);
+    }
+
+    pub fn real(s: Solver) Sort {
+        return s.makeSort(c.Z3_mk_real_sort);
+    }
+
+    pub fn float(s: Solver, ebits: u32, sbits: u32) Sort {
+        const sort = c.Z3_mk_fpa_sort(s.ctx.inner, ebits, sbits);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
+    }
+
+    pub fn float32(s: Solver) Sort {
+        const sort = c.Z3_mk_fpa_sort(s.ctx.inner, 8, 24);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
+    }
+
+    pub fn double(s: Solver) Sort {
+        const sort = c.Z3_mk_fpa_sort(s.ctx.inner, 11, 53);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
+    }
+
+    pub fn string(s: Solver) Sort {
+        return s.makeSort(c.Z3_mk_string_sort);
+    }
+
+    pub fn bv(s: Solver, sz: u32) Sort {
+        const sort = c.Z3_mk_bv_sort(s.ctx.inner, sz);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
+    }
+
+    pub fn array(s: Solver, domain: Sort, range: Sort) Sort {
+        const sort = c.Z3_mk_array_sort(s.ctx.inner, domain.z3_sort, range.z3_sort);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
+    }
+
+    pub fn set(s: Solver, elt: *const Sort) Sort {
+        const sort = c.Z3_mk_set_sort(s.ctx.inner, elt.z3_sort);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
+    }
+
+    pub fn seq(s: Solver, elt: *const Sort) Sort {
+        const sort = c.Z3_mk_seq_sort(s.ctx.inner, elt.z3_sort);
+        c.Z3_inc_ref(s.ctx.inner, sort);
+        return .{ .ctx = s.ctx, .inner = sort };
     }
 };
 
-const PartialModel = struct {
-    m: *Model,
-    raw: z3.Z3_model,
+pub const Model = struct {
+    ctx: Context,
+    inner: c.Z3_model,
 
-    pub fn deinit(p: *PartialModel) void {
-        z3.Z3_model_dec_ref(p.m.ctx, p.raw);
+    pub fn deinit(m: Model) void {
+        c.Z3_model_dec_ref(m.ctx.inner, m.inner);
     }
 
-    pub fn toString(p: *const PartialModel) []const u8 {
-        const str = z3.Z3_model_to_string(p.m.ctx, p.raw);
-        return std.mem.sliceTo(str, 0);
-    }
+    pub fn eval(m: Model, ast: anytype, model_completion: bool) ?@TypeOf(ast) {
+        var ret = ast;
+        if (c.Z3_model_eval(
+            m.ctx.inner,
+            m.inner,
+            ast.ast,
+            model_completion,
+            &ret.ast,
+        )) {
+            c.Z3_inc_ref(m.ctx.inner, ret.ast);
+            return ret;
+        }
 
-    pub fn isTrue(p: *PartialModel, v: anytype) bool {
-        var value: z3.Z3_ast = undefined;
-        if (!z3.Z3_model_eval(p.m.ctx, p.raw, v.ast, true, &value)) return false;
-        const boolean: Check = @enumFromInt(z3.Z3_get_bool_value(p.m.ctx, value));
-        return boolean == .true;
+        return null;
     }
+};
+
+/// Result of a satisfiability query.
+pub const SatResult = enum(i2) {
+    /// The query is unsatisfiable.
+    unsat = -1,
+    /// The query was interrupted, timed out or otherwise failed.
+    unknown = 0,
+    /// The query is satisfiable.
+    sat = 1,
 };

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -178,6 +178,7 @@ pub const Int = struct {
     ast: c.Z3_ast,
 
     const A = Ast(.int);
+    pub const toString = A.toString;
     pub const add = A.add;
     pub const sub = A.sub;
     pub const mul = A.mul;
@@ -199,36 +200,43 @@ pub const Real = struct {
     ast: c.Z3_ast,
 
     const A = Ast(.real);
+    pub const toString = A.toString;
 };
 pub const Float = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
     const A = Ast(.float);
+    pub const toString = A.toString;
 };
 pub const Float32 = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
     const A = Ast(.float32);
+    pub const toString = A.toString;
 };
 pub const Float64 = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
     const A = Ast(.float64);
+    pub const toString = A.toString;
 };
 pub const String = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
     const A = Ast(.string);
+    pub const toString = A.toString;
 };
 pub const Bitvector = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
     const A = Ast(.bv);
+    pub const toString = A.toString;
+
     pub const bvadd = A.bvadd;
     pub const bvsub = A.bvsub;
     pub const bvmul = A.bvmul;
@@ -253,6 +261,8 @@ pub const Array = struct {
     ast: c.Z3_ast,
 
     const A = Ast(.array);
+    pub const toString = A.toString;
+
     pub const select = A.select;
     pub const asSet = A.asSet;
 };
@@ -261,12 +271,14 @@ pub const Set = struct {
     ast: c.Z3_ast,
 
     const A = Ast(.set);
+    pub const toString = A.toString;
 };
 pub const Seq = struct {
     ctx: *Context,
     ast: c.Z3_ast,
 
     const A = Ast(.seq);
+    pub const toString = A.toString;
 };
 
 pub const Dynamic = struct {
@@ -296,17 +308,26 @@ pub fn Ast(comptime ast_kind: AstKind) type {
         pub fn deinit(self: anytype) void {
             c.Z3_dec_ref(self.ctx.inner, self.ast);
         }
+        pub fn toString(self: anytype) ?[]const u8 {
+            return if (c.Z3_ast_to_string(self.ctx.inner, self.ast)) |s| std.mem.sliceTo(s, 0) else null;
+        }
 
         inline fn verify(comptime ok: bool, comptime message: []const u8) void {
             comptime if (!ok)
                 @compileError(std.fmt.comptimePrint(message ++ ".  found '{t}'", .{ast_kind}));
         }
-        fn binop(R: type, lhs: anytype, rhs: @TypeOf(lhs.*), func: @TypeOf(c.Z3_mk_div)) R {
+        inline fn Child(T: type) type {
+            return switch (@typeInfo(T)) {
+                .pointer => |p| p.child,
+                else => T,
+            };
+        }
+        fn binop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
             const ast = func(lhs.ctx.inner, lhs.ast, rhs.ast);
             c.Z3_inc_ref(lhs.ctx.inner, ast);
             return .{ .ast = ast, .ctx = lhs.ctx };
         }
-        fn varop(lhs: anytype, rhss: []const @TypeOf(lhs.*), comptime func: @TypeOf(c.Z3_mk_add)) @TypeOf(lhs.*) {
+        fn varop(lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) Child(@TypeOf(lhs)) {
             var buf: [16]c.Z3_ast = undefined;
             if (buf.len < rhss.len + 1) @panic("varop only supports up to 15 rhs args.");
             buf[0] = lhs.ast;
@@ -317,53 +338,53 @@ pub fn Ast(comptime ast_kind: AstKind) type {
         }
 
         // *** Numeric ops ***
-        fn numericBinop(R: type, lhs: anytype, rhs: @TypeOf(lhs.*), func: @TypeOf(c.Z3_mk_div)) R {
+        fn numericBinop(R: type, lhs: anytype, rhs: Child(@TypeOf(lhs)), func: @TypeOf(c.Z3_mk_div)) R {
             verify(ast_kind.isNumeric(), "expected numeric ast kind");
             return binop(R, lhs, rhs, func);
         }
-        fn numericVarop(lhs: anytype, rhss: []const @TypeOf(lhs.*), comptime func: @TypeOf(c.Z3_mk_add)) @TypeOf(lhs.*) {
+        fn numericVarop(lhs: anytype, rhss: []const Child(@TypeOf(lhs)), comptime func: @TypeOf(c.Z3_mk_add)) Child(@TypeOf(lhs)) {
             verify(ast_kind.isNumeric(), "expected numeric ast kind");
             return varop(lhs, rhss, func);
         }
 
-        pub fn div(lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
-            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_div);
+        pub fn div(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_div);
         }
-        pub fn rem(lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
-            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_rem);
+        pub fn rem(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_rem);
         }
-        pub fn mod(lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
-            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_mod);
+        pub fn mod(lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_mod);
         }
-        pub fn power(lhs: anytype, rhs: @TypeOf(lhs.*)) Real {
-            return numericBinop(@TypeOf(lhs.*), lhs, rhs, c.Z3_mk_power);
+        pub fn power(lhs: anytype, rhs: Child(@TypeOf(lhs))) Real {
+            return numericBinop(Child(@TypeOf(lhs)), lhs, rhs, c.Z3_mk_power);
         }
 
-        pub fn lt(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
+        pub fn lt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_lt);
         }
-        pub fn le(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
+        pub fn le(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_le);
         }
-        pub fn gt(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
+        pub fn gt(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_gt);
         }
-        pub fn ge(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
+        pub fn ge(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_ge);
         }
-        pub fn eq(lhs: anytype, rhs: @TypeOf(lhs.*)) Bool {
+        pub fn eq(lhs: anytype, rhs: Child(@TypeOf(lhs))) Bool {
             return numericBinop(Bool, lhs, rhs, c.Z3_mk_eq);
         }
 
-        pub fn add(lhs: anytype, rhss: []const @TypeOf(lhs.*)) @TypeOf(lhs.*) {
+        pub fn add(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
             return numericVarop(lhs, rhss, c.Z3_mk_add);
         }
 
-        pub fn sub(lhs: anytype, rhss: []const @TypeOf(lhs.*)) @TypeOf(lhs.*) {
+        pub fn sub(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
             return numericVarop(lhs, rhss, c.Z3_mk_sub);
         }
 
-        pub fn mul(lhs: anytype, rhss: []const @TypeOf(lhs.*)) @TypeOf(lhs.*) {
+        pub fn mul(lhs: anytype, rhss: []const Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
             return numericVarop(lhs, rhss, c.Z3_mk_mul);
         }
 
@@ -475,20 +496,20 @@ pub fn Ast(comptime ast_kind: AstKind) type {
             return binop(Bool, lhs, rhs, c.Z3_mk_implies);
         }
 
-        pub fn not(m: *Model, op: Bool) Bool {
-            const ast = c.Z3_mk_not(m.ctx, op.ast);
+        pub fn not(op: Bool) Bool {
+            const ast = c.Z3_mk_not(op.ctx.inner, op.ast);
             c.Z3_inc_ref(op.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = &m.ctx };
+            return .{ .ast = ast, .ctx = &op.ctx };
         }
 
         /// Create an AST node representing an if-then-else. If `predicate` is true,
         /// the node results in `lhs`, otherwise it results in `rhs`.
         ///
         /// `rhs` and `lhs` must be the same sort, and the result type is that sort.
-        pub fn ite(m: *Model, predicate: Bool, lhs: anytype, rhs: @TypeOf(lhs.*)) @TypeOf(lhs.*) {
-            const ast = c.Z3_mk_ite(m.ctx.inner, predicate.ast, lhs.ast, rhs.ast);
-            c.Z3_inc_ref(m.ctx.inner, ast);
-            return .{ .ast = ast, .ctx = &m.ctx };
+        pub fn ite(predicate: Bool, lhs: anytype, rhs: Child(@TypeOf(lhs))) Child(@TypeOf(lhs)) {
+            const ast = c.Z3_mk_ite(predicate.ctx.inner, predicate.ast, lhs.ast, rhs.ast);
+            c.Z3_inc_ref(predicate.ctx.inner, ast);
+            return .{ .ast = ast, .ctx = predicate.ctx };
         }
     };
 }
@@ -619,6 +640,11 @@ pub const Model = struct {
 
     pub fn @"true"(m: *Model) Bool {
         const ast = c.Z3_mk_true(m.ctx.inner);
+        c.Z3_inc_ref(m.ctx.inner, ast);
+        return .{ .ctx = &m.ctx, .ast = ast };
+    }
+    pub fn @"false"(m: *Model) Bool {
+        const ast = c.Z3_mk_false(m.ctx.inner);
         c.Z3_inc_ref(m.ctx.inner, ast);
         return .{ .ctx = &m.ctx, .ast = ast };
     }

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -330,7 +330,10 @@ pub const Dynamic = struct {
                     ),
                 ));
                 switch (sort_kind) {
-                    .bool => return .{ .ctx = self.ctx, .ast = self.ast },
+                    .bool => {
+                        c.Z3_inc_ref(self.ctx.inner, self.ast);
+                        return .{ .ctx = self.ctx, .ast = self.ast };
+                    },
                     else => return null,
                 }
             },
@@ -651,15 +654,11 @@ pub const Model = struct {
     }
 
     pub fn constant(m: *Model, comptime tag: Ast.Tag, name: ?[:0]const u8, args: anytype) tag.Data() {
-        const sort = m.ctx.getSort(tag, args);
-        const sym = Symbol.asZ3(.{ .string = name }, &m.ctx);
-        const ast = c.Z3_mk_const(m.ctx.inner, sym, sort.inner);
-        c.Z3_inc_ref(m.ctx.inner, ast);
-        return .{ .ctx = &m.ctx, .ast = ast };
+        const sort = @call(.auto, @field(Model, @tagName(tag)), .{m} ++ args);
+        return m.constantWithSort(tag, name, sort);
     }
 
-    pub fn constantFloat(m: *Model, T: type, name: ?[:0]const u8) Float {
-        const sort = m.float(T);
+    pub fn constantWithSort(m: *Model, comptime tag: Ast.Tag, name: ?[:0]const u8, sort: Sort) tag.Data() {
         const sym = Symbol.asZ3(.{ .string = name }, &m.ctx);
         const ast = c.Z3_mk_const(m.ctx.inner, sym, sort.inner);
         c.Z3_inc_ref(m.ctx.inner, ast);
@@ -724,13 +723,29 @@ pub const Model = struct {
         return m.ctx.getSortByName(tag, "Z3_mk_fpa_sort", .{ ebits, sbits });
     }
 
+    pub fn float16(m: *Model) Sort {
+        return m.float(f16);
+    }
+
+    pub fn float32(m: *Model) Sort {
+        return m.float(f32);
+    }
+
+    pub fn float64(m: *Model) Sort {
+        return m.float(f64);
+    }
+
+    pub fn float128(m: *Model) Sort {
+        return m.float(f128);
+    }
+
     pub fn string(m: *Model) Sort {
         return m.ctx.getSort(.string, .{});
     }
 
-    pub fn bv(m: Model, sz: u32) Sort {
+    pub fn bv(m: *Model, sz: u32) Sort {
         const sort = c.Z3_mk_bv_sort(m.ctx.inner, sz);
-        c.Z3_inc_ref(m.ctx.inner, sort);
+        c.Z3_inc_ref(m.ctx.inner, c.Z3_sort_to_ast(m.ctx.inner, sort));
         return .{ .ctx = &m.ctx, .inner = sort };
     }
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,7 +1,6 @@
 const z3 = @import("z3");
 const std = @import("std");
 const testing = std.testing;
-// const gpa = testing.allocator;
 
 test "context" {
     var ctx = z3.Context.init(&.{.{ .proof = true }});
@@ -106,4 +105,30 @@ test "ite" {
 
     const ite = solver.false().ite(solver.fromInt(0), solver.fromInt(1));
     try testing.expectEqualStrings("(ite false 0 1)", ite.toString().?);
+}
+
+test "array example 1" {
+    var solver: z3.Model = .initSolver();
+    defer solver.deinit();
+    const int_sort = solver.int().inner;
+    const a1 = solver.constant(.array, "a1", .{ int_sort, int_sort });
+    const a2 = solver.constant(.array, "a2", .{ int_sort, int_sort });
+    const idx1 = solver.constant(.int, "idx1", .{});
+    const idx2 = solver.constant(.int, "idx2", .{});
+    const idx3 = solver.constant(.int, "idx3", .{});
+    const v1 = solver.constant(.int, "v1", .{});
+    const v2 = solver.constant(.int, "v2", .{});
+    const st1 = a1.store(idx1, v1);
+    const st2 = a2.store(idx2, v2);
+    const sel1 = a1.select(idx3);
+    const sel2 = a2.select(idx3);
+    const antecedent = st1.eq(st2);
+    // idx1 = idx3 or  idx2 = idx3 or select(a1, idx3) = select(a2, idx3)
+    const consequent = idx1.eq(idx3).@"or"(&.{ idx2.eq(idx3), sel1.eq(sel2) });
+    const thm = antecedent.implies(consequent);
+    // prove store(a1, idx1, v1) = store(a2, idx2, v2) implies (idx1 = idx3 or idx2 = idx3 or select(a1, idx3) = select(a2, idx3))
+    solver.push();
+    solver.assert(thm.not());
+    try testing.expectEqual(.unsat, solver.check());
+    solver.pop(1);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -43,7 +43,7 @@ test "bitvectors" {
 
     const a = solver.constant(.bv, "a", .{64});
     const b = solver.constant(.bv, "b", .{64});
-    const two = solver.bvFromInt64(2, 64); // ast::BV::from_i64(2, 64);
+    const two = solver.bvFromInt64(2, 64);
 
     solver.assert(a.bvsgt(b));
     solver.assert(b.bvsgt(two));
@@ -82,4 +82,20 @@ test "optimize unknown" {
 
     try testing.expectEqual(.unknown, optimize.check());
     try testing.expect(optimize.getReasonUnknown() != null);
+}
+
+test "dynamic as set" {
+    var optimize: z3.Model = .initConfig(.optimize, &.{});
+    defer optimize.deinit();
+    const set_sort = optimize.set(optimize.int());
+    const array_sort = optimize.array(optimize.int(), optimize.int());
+    const array_of_sets = optimize.constant(.array, "array_of_sets", .{ optimize.int().inner, set_sort.inner });
+    try testing.expect(array_of_sets
+        .select(optimize.fromInt64(0))
+        .asSet() != null);
+
+    const array_of_arrays = optimize.constant(.array, "array_of_arrays", .{ optimize.int().inner, array_sort.inner });
+    try testing.expectEqual(null, array_of_arrays
+        .select(optimize.fromInt64(0))
+        .asSet());
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,0 +1,61 @@
+const z3 = @import("z3");
+const std = @import("std");
+const testing = std.testing;
+const gpa = testing.allocator;
+
+test "context" {
+    var ctx = try z3.Context.init(gpa, &.{.{ "proof", "true" }});
+    defer ctx.deinit(gpa);
+}
+
+test "solve for model" {
+    var solver: z3.Solver = try .init(gpa);
+    defer solver.deinit(gpa);
+
+    const x = solver.constant(.int, "x", .{});
+    const y = solver.constant(.int, "y", .{});
+
+    const zero = solver.int64(0);
+    const two = solver.int64(2);
+    const seven = solver.int64(7);
+
+    solver.assert(x.gt(y));
+    solver.assert(y.gt(zero));
+    solver.assert(y.rem(seven).eq(two));
+
+    const x_plus_two = x.add(&.{two});
+    solver.assert(x_plus_two.gt(seven));
+    try testing.expectEqual(.sat, solver.check());
+
+    const model = solver.getLastModel();
+    defer model.deinit();
+    const xv = model.eval(x, true).?.int64().?;
+    const yv = model.eval(y, true).?.int64().?;
+
+    try testing.expect(xv > yv);
+    try testing.expectEqual(2, @mod(yv, 7));
+    try testing.expect(xv + 2 > 7);
+}
+
+test "bitvectors" {
+    var solver: z3.Solver = try .init(gpa);
+    defer solver.deinit(gpa);
+
+    const a = solver.constant(.bv, "a", .{64});
+    const b = solver.constant(.bv, "b", .{64});
+    const two = solver.bvFromInt64(2, 64); // ast::BV::from_i64(2, 64);
+
+    solver.assert(a.bvsgt(b));
+    solver.assert(b.bvsgt(two));
+    const b_plus_two = b.bvadd(two);
+    solver.assert(b_plus_two.bvsgt(a));
+    try testing.expectEqual(.sat, solver.check());
+
+    const model = solver.getLastModel();
+    defer model.deinit();
+    const av = model.eval(a, true).?.int64().?;
+    const bv = model.eval(b, true).?.int64().?;
+    try testing.expect(av > bv);
+    try testing.expect(bv > 2);
+    try testing.expect(bv + 2 > av);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -136,3 +136,21 @@ test "array example 1" {
     try testing.expectEqual(.unsat, solver.check());
     solver.pop(1);
 }
+
+fn expectFloatSize(solver: *z3.Model, T: type, comptime tag: z3.Ast.Tag, ebits: u32, sbits: u32) !void {
+    try testing.expect(@field(solver.ctx.cached_sorts, @tagName(tag)) == null);
+    const float32 = solver.constantFloat(T, @tagName(tag));
+    try testing.expect(@field(solver.ctx.cached_sorts, @tagName(tag)) != null);
+    try std.testing.expectEqual(ebits, float32.getSort().exponentSize());
+    try std.testing.expectEqual(sbits, float32.getSort().significandSize());
+}
+
+test "float sizes" {
+    var solver: z3.Model = .initSolver();
+    defer solver.deinit();
+
+    try expectFloatSize(&solver, f16, .float16, 5, 11);
+    try expectFloatSize(&solver, f32, .float32, 8, 24);
+    try expectFloatSize(&solver, f64, .float64, 11, 53);
+    try expectFloatSize(&solver, f128, .float128, 15, 113);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -99,3 +99,11 @@ test "dynamic as set" {
         .select(optimize.fromInt64(0))
         .asSet());
 }
+
+test "ite" {
+    var solver: z3.Model = .initSolver();
+    defer solver.deinit();
+
+    const ite = solver.false().ite(solver.fromInt(0), solver.fromInt(1));
+    try testing.expectEqualStrings("(ite false 0 1)", ite.toString().?);
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9,7 +9,7 @@ test "context" {
 }
 
 test "solve for model" {
-    var solver: z3.Solver = try .init(gpa);
+    var solver: z3.Model = try .init(.solver, gpa);
     defer solver.deinit(gpa);
 
     const x = solver.constant(.int, "x", .{});
@@ -38,7 +38,7 @@ test "solve for model" {
 }
 
 test "bitvectors" {
-    var solver: z3.Solver = try .init(gpa);
+    var solver: z3.Model = try .init(.solver, gpa);
     defer solver.deinit(gpa);
 
     const a = solver.constant(.bv, "a", .{64});
@@ -58,4 +58,29 @@ test "bitvectors" {
     try testing.expect(av > bv);
     try testing.expect(bv > 2);
     try testing.expect(bv + 2 > av);
+}
+
+test "optimize unknown" {
+    var optimize: z3.Model = try .initConfig(
+        .optimize,
+        gpa,
+        &.{.{ "timeout", "1" }}, // 1 ms timeout
+    );
+    defer optimize.deinit(gpa);
+
+    // An open problem: find a model for x^3 + y^3 + z^3 == 42
+    // See: https://en.wikipedia.org/wiki/Sums_of_three_cubes
+    const x = optimize.constant(.int, "x", .{});
+    const y = optimize.constant(.int, "y", .{});
+    const z = optimize.constant(.int, "z", .{});
+    const x_cube = x.mul(&.{ x, x });
+    const y_cube = y.mul(&.{ y, y });
+    const z_cube = z.mul(&.{ z, z });
+    const sum_of_cubes = x_cube.add(&.{ y_cube, z_cube });
+    const sum_of_cubes_is_42 = sum_of_cubes.eq(optimize.int64(42));
+
+    optimize.assert(sum_of_cubes_is_42);
+
+    try testing.expectEqual(.unknown, optimize.check());
+    try testing.expect(optimize.getReasonUnknown() != null);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3,10 +3,10 @@ const std = @import("std");
 const testing = std.testing;
 
 test "context" {
-    var ctx = z3.Context.init(&.{
-        .{ .proof = true },
-        .{ .encoding = .ascii },
-        .{ .timeout = 10 },
+    var ctx = z3.Context.init(.{
+        .proof = true,
+        .encoding = .ascii,
+        .timeout = 10,
     });
     defer ctx.deinit();
 }
@@ -66,7 +66,7 @@ test "bitvectors" {
 test "optimize unknown" {
     var optimize: z3.Model = .initConfig(
         .optimize,
-        &.{.{ .timeout = 1 }}, // 1 ms timeout
+        .{ .timeout = 1 }, // 1 ms timeout
     );
     defer optimize.deinit();
 
@@ -88,7 +88,7 @@ test "optimize unknown" {
 }
 
 test "dynamic as set" {
-    var optimize: z3.Model = .initConfig(.optimize, &.{});
+    var optimize: z3.Model = .initConfig(.optimize, .{});
     defer optimize.deinit();
     const set_sort = optimize.set(optimize.int());
     const array_sort = optimize.array(optimize.int(), optimize.int());

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -1,23 +1,23 @@
 const z3 = @import("z3");
 const std = @import("std");
 const testing = std.testing;
-const gpa = testing.allocator;
+// const gpa = testing.allocator;
 
 test "context" {
-    var ctx = try z3.Context.init(gpa, &.{.{ "proof", "true" }});
-    defer ctx.deinit(gpa);
+    var ctx = z3.Context.init(&.{.{ .proof = true }});
+    defer ctx.deinit();
 }
 
 test "solve for model" {
-    var solver: z3.Model = try .init(.solver, gpa);
-    defer solver.deinit(gpa);
+    var solver: z3.Model = .initSolver();
+    defer solver.deinit();
 
     const x = solver.constant(.int, "x", .{});
     const y = solver.constant(.int, "y", .{});
 
-    const zero = solver.int64(0);
-    const two = solver.int64(2);
-    const seven = solver.int64(7);
+    const zero = solver.fromInt64(0);
+    const two = solver.fromInt64(2);
+    const seven = solver.fromInt64(7);
 
     solver.assert(x.gt(y));
     solver.assert(y.gt(zero));
@@ -29,8 +29,8 @@ test "solve for model" {
 
     const model = solver.getLastModel();
     defer model.deinit();
-    const xv = model.eval(x, true).?.int64().?;
-    const yv = model.eval(y, true).?.int64().?;
+    const xv = model.eval(x, true).?.asInt64().?;
+    const yv = model.eval(y, true).?.asInt64().?;
 
     try testing.expect(xv > yv);
     try testing.expectEqual(2, @mod(yv, 7));
@@ -38,8 +38,8 @@ test "solve for model" {
 }
 
 test "bitvectors" {
-    var solver: z3.Model = try .init(.solver, gpa);
-    defer solver.deinit(gpa);
+    var solver: z3.Model = .initSolver();
+    defer solver.deinit();
 
     const a = solver.constant(.bv, "a", .{64});
     const b = solver.constant(.bv, "b", .{64});
@@ -53,20 +53,19 @@ test "bitvectors" {
 
     const model = solver.getLastModel();
     defer model.deinit();
-    const av = model.eval(a, true).?.int64().?;
-    const bv = model.eval(b, true).?.int64().?;
+    const av = model.eval(a, true).?.asInt64().?;
+    const bv = model.eval(b, true).?.asInt64().?;
     try testing.expect(av > bv);
     try testing.expect(bv > 2);
     try testing.expect(bv + 2 > av);
 }
 
 test "optimize unknown" {
-    var optimize: z3.Model = try .initConfig(
+    var optimize: z3.Model = .initConfig(
         .optimize,
-        gpa,
-        &.{.{ "timeout", "1" }}, // 1 ms timeout
+        &.{.{ .timeout = 1 }}, // 1 ms timeout
     );
-    defer optimize.deinit(gpa);
+    defer optimize.deinit();
 
     // An open problem: find a model for x^3 + y^3 + z^3 == 42
     // See: https://en.wikipedia.org/wiki/Sums_of_three_cubes
@@ -77,7 +76,7 @@ test "optimize unknown" {
     const y_cube = y.mul(&.{ y, y });
     const z_cube = z.mul(&.{ z, z });
     const sum_of_cubes = x_cube.add(&.{ y_cube, z_cube });
-    const sum_of_cubes_is_42 = sum_of_cubes.eq(optimize.int64(42));
+    const sum_of_cubes_is_42 = sum_of_cubes.eq(optimize.fromInt64(42));
 
     optimize.assert(sum_of_cubes_is_42);
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -92,12 +92,20 @@ test "dynamic as set" {
     defer optimize.deinit();
     const set_sort = optimize.set(optimize.int());
     const array_sort = optimize.array(optimize.int(), optimize.int());
-    const array_of_sets = optimize.constant(.array, "array_of_sets", .{ optimize.int().inner, set_sort.inner });
+    const array_of_sets = optimize.constantWithSort(
+        .array,
+        "array_of_sets",
+        optimize.array(optimize.int(), set_sort),
+    );
     try testing.expect(array_of_sets
         .select(optimize.fromInt64(0))
         .asSet() != null);
 
-    const array_of_arrays = optimize.constant(.array, "array_of_arrays", .{ optimize.int().inner, array_sort.inner });
+    const array_of_arrays = optimize.constant(
+        .array,
+        "array_of_arrays",
+        .{ optimize.int(), array_sort },
+    );
     try testing.expectEqual(null, array_of_arrays
         .select(optimize.fromInt64(0))
         .asSet());
@@ -114,7 +122,7 @@ test "ite" {
 test "array example 1" {
     var solver: z3.Model = .initSolver();
     defer solver.deinit();
-    const int_sort = solver.int().inner;
+    const int_sort = solver.int();
     const a1 = solver.constant(.array, "a1", .{ int_sort, int_sort });
     const a2 = solver.constant(.array, "a2", .{ int_sort, int_sort });
     const idx1 = solver.constant(.int, "idx1", .{});
@@ -137,9 +145,9 @@ test "array example 1" {
     solver.pop(1);
 }
 
-fn expectFloatSize(solver: *z3.Model, T: type, comptime tag: z3.Ast.Tag, ebits: u32, sbits: u32) !void {
+fn expectFloatSize(solver: *z3.Model, comptime tag: z3.Ast.Tag, ebits: u32, sbits: u32) !void {
     try testing.expect(@field(solver.ctx.cached_sorts, @tagName(tag)) == null);
-    const float32 = solver.constantFloat(T, @tagName(tag));
+    const float32 = solver.constant(tag, @tagName(tag), .{});
     try testing.expect(@field(solver.ctx.cached_sorts, @tagName(tag)) != null);
     try std.testing.expectEqual(ebits, float32.getSort().exponentSize());
     try std.testing.expectEqual(sbits, float32.getSort().significandSize());
@@ -149,8 +157,8 @@ test "float sizes" {
     var solver: z3.Model = .initSolver();
     defer solver.deinit();
 
-    try expectFloatSize(&solver, f16, .float16, 5, 11);
-    try expectFloatSize(&solver, f32, .float32, 8, 24);
-    try expectFloatSize(&solver, f64, .float64, 11, 53);
-    try expectFloatSize(&solver, f128, .float128, 15, 113);
+    try expectFloatSize(&solver, .float16, 5, 11);
+    try expectFloatSize(&solver, .float32, 8, 24);
+    try expectFloatSize(&solver, .float64, 11, 53);
+    try expectFloatSize(&solver, .float128, 15, 113);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -3,7 +3,11 @@ const std = @import("std");
 const testing = std.testing;
 
 test "context" {
-    var ctx = z3.Context.init(&.{.{ .proof = true }});
+    var ctx = z3.Context.init(&.{
+        .{ .proof = true },
+        .{ .encoding = .ascii },
+        .{ .timeout = 10 },
+    });
     defer ctx.deinit();
 }
 


### PR DESCRIPTION
the current design doesn't support mk_*_sort methods with more than one arg.  this patch attempts to solve that by roughly following the structures from prove-rs/z3.rs.

TODO: add back support for `optimize` and various methods such as implies(), ite(), etc.

* add Context type
	* add errorHandler which prints output from `Z3_get_error_msg()`
* add tests.zig with passing tests "solve for model" and "bitvectors"
* update example.basic() to new API
* install artifacts and enable valgrind in build.zig so we can use valgrind.  not sure if this has much value since z3 seems to report some leaks on its own.